### PR TITLE
Change form labels on /cloud/contact-us sentence case

### DIFF
--- a/templates/cloud/contact-us.html
+++ b/templates/cloud/contact-us.html
@@ -20,19 +20,19 @@
             <h3>About you</h3>
             <ul class="no-bullets">          
                 <li class="mktFormReq mktField">    
-                    <label for="FirstName" class="mktoLabel">First Name:</label>
+                    <label for="FirstName" class="mktoLabel">First name:</label>
                     <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
                 </li>
-                <li class="mktFormReq mktField">    
-                    <label for="LastName" class="mktoLabel">Last Name:</label>
+                <li class="mktFormReq mktField">
+                    <label for="LastName" class="mktoLabel">Last name:</label>
                     <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
                 </li>
-                <li class="mktFormReq mktField">    
-                    <label for="Email" class="mktoLabel">Email Address:</label>
+                <li class="mktFormReq mktField">
+                    <label for="Email" class="mktoLabel">Email address:</label>
                     <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
                 </li>
-                <li class="mktFormReq mktField">    
-                    <label for="Phone" class="mktoLabel">Phone Number:</label>
+                <li class="mktFormReq mktField">
+                    <label for="Phone" class="mktoLabel">Phone number:</label>
                     <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
                 </li>
                 {% include "shared/forms/_country.html" %}
@@ -46,9 +46,9 @@
         </fieldset>
         <fieldset>
             <h3>About your company</h3>
-            <ul class="no-bullets"> 
-                <li class="mktFormReq mktField">    
-                    <label for="Company" class="mktoLabel">Company Name:</label>
+            <ul class="no-bullets">
+                <li class="mktFormReq mktField">
+                    <label for="Company" class="mktoLabel">Company name:</label>
                     <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
                 </li>
                 {% include "shared/forms/_industry.html" %}  


### PR DESCRIPTION
## Done
Changed the form fields on /cloud/contact-us to sentence case to match style guide.

## QA
- Navigate to /cloud/contact-us
- Check all form labels are sentence case

## Issue / Card
Fixes #749 