### PR TITLE
Change email input form type to "email"

### DIFF
--- a/templates/shared/contextual_footers/_cloud_contact_us.html
+++ b/templates/shared/contextual_footers/_cloud_contact_us.html
@@ -8,7 +8,7 @@
         <ul class='contextual-footer__list mktoFormRow clearfix'>
             <li class='mktoFormCol'>
                 <label class="off-left mktoLabel" for='Email'>Your email</label>
-                <input type="text" placeholder="Your email" class='mktoField mktoTextField' name='Email' id='Email' required />
+                <input type="email" placeholder="Your email" class='mktoField mktoTextField' name='Email' id='Email' required />
             </li>
             <li class="mktField mktLblRight">
                 <span class="mktInput mktLblRight">


### PR DESCRIPTION
## Done

Added HTML5 validation to footer newsletter subscribe form

## QA

- Navigate to /cloud
- Scroll to bottom
- Submit with field empty - should receive feedback saying field is required
- Submit with string 'fooo' - should receive feedback saying field needs string in email format

## Issue / Card

Fixes: #344 