### PR TITLE
Cloud training updates

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -866,8 +866,8 @@ body.cloud-storage {
   }
 
   .row--training__image {
-    position: absolute;
-    top: -122px;
+    position: relative;
+    top: -61px;
     right: -20px;
   }
 
@@ -1409,8 +1409,7 @@ body.cloud-storage {
 @media only screen and (min-width : $breakpoint-large) {
 
   .row--training__image {
-    position: absolute;
-    right: -20px;
+    top: -122px;
   }
 
   body.cloud-openstack-managed-cloud {

--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -838,7 +838,7 @@ body.cloud-storage {
     .training-list li:first-child {
       border-bottom: 1px dotted #888;
       padding-bottom: 20px;
-      margin-bottom: 20px;
+      margin-bottom: 35px;
       display: block;
       float: left;
     }

--- a/templates/cloud/openstack/training/index.html
+++ b/templates/cloud/openstack/training/index.html
@@ -55,7 +55,7 @@
       <div class="equal-height--vertical-divider__item seven-col">
         <h3>Onsite training</h3>
         <p>3-day hands-on course at your premises for up to 15 students, with a minimum of 8 students required, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
-        <p><a class="external" href="https://docs.google.com/document/d/1O0ycluh-IxprMa1aSmJidoPW1RxVj0g891UvubODC_g/edit#heading=h.wlksava6n8gl">Read the course outline (PDF)</a></p>
+        <p><a class="external" href="https://docs.google.com/document/d/1O0ycluh-IxprMa1aSmJidoPW1RxVj0g891UvubODC_g/edit#heading=h.wlksava6n8gl">Read the course outline</a></p>
       </div>
       <div class="equal-height--vertical-divider__item five-col last-col" itemscope itemtype="http://data-vocabulary.org/Event">
         <dl class="course-details">

--- a/templates/cloud/openstack/training/index.html
+++ b/templates/cloud/openstack/training/index.html
@@ -55,7 +55,7 @@
       <div class="equal-height--vertical-divider__item seven-col">
         <h3>Onsite training</h3>
         <p>3-day hands-on course at your premises for up to 15 students, with a minimum of 8 students required, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
-        <p><a class="external" href="https://docs.google.com/document/d/1O0ycluh-IxprMa1aSmJidoPW1RxVj0g891UvubODC_g/edit#heading=h.wlksava6n8gl">Read the course outline</a></p>
+        <p><a class="external" href="https://assets.ubuntu.com/v1/1f2e7629-Ubuntu_Server_Administration_Training_06.07.16-2-2.pdf">Read the course outline</a></p>
       </div>
       <div class="equal-height--vertical-divider__item five-col last-col" itemscope itemtype="http://data-vocabulary.org/Event">
         <dl class="course-details">

--- a/templates/cloud/openstack/training/index.html
+++ b/templates/cloud/openstack/training/index.html
@@ -2,9 +2,9 @@
 
 {% block title %}Training | Cloud{% endblock %}
 
-{% block meta_description %}Canonical run OpenStack training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
+{% block meta_description %}Canonical run OpenStack and Ubuntu training programmes to suit all environments and all levels of experience.{% endblock meta_description %}
 
-{% block meta_keywords %}cloud training, openstack training, Ubuntu OpenStack, private cloud, Canonical training{% endblock meta_keywords %}
+{% block meta_keywords %}cloud training, openstack training, Ubuntu OpenStack, private cloud, Canonical training, Ubuntu Server, Ubuntu Training{% endblock meta_keywords %}
 
 {% block second_level_nav_items %}
   {% include "templates/_nav_breadcrumb.html" with section_title="Cloud" subsection_title="OpenStack" page_title="Jumpstart" %}
@@ -36,8 +36,7 @@
           <dt>Duration</dt>
           <dd>3 days</dd>
           <dt>Cost</dt>
-          <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span
-            itemprop="price" content="1950.00">1,950</span> per attendee</dd>
+          <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="1950.00">1,950</span> per attendee</dd>
           <dt>Availability</dt>
           <dd>Open admissions</dd>
         </dl>
@@ -55,8 +54,8 @@
       <div class="equal-height--vertical-divider twelve-col">
       <div class="equal-height--vertical-divider__item seven-col">
         <h3>Onsite training</h3>
-        <p>3-day hands-on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
-        <p><a class="external" href="https://insights.ubuntu.com/wp-content/uploads/226b/067_CAN_OpenStack_Fundamentals_Flyer_A4_v4_Screen.pdf">Read the course outline (PDF)</a></p>
+        <p>3-day hands-on course at your premises for up to 15 students, with a minimum of 8 students required, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
+        <p><a class="external" href="https://docs.google.com/document/d/1O0ycluh-IxprMa1aSmJidoPW1RxVj0g891UvubODC_g/edit#heading=h.wlksava6n8gl">Read the course outline (PDF)</a></p>
       </div>
       <div class="equal-height--vertical-divider__item five-col last-col" itemscope itemtype="http://data-vocabulary.org/Event">
         <dl class="course-details">
@@ -64,11 +63,11 @@
           <dd itemprop="duration">3 days</dd>
           <dt>Cost</dt>
           <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span
-            itemprop="price" content="19500.00">19,500</span> up to 15 attendees</dd>
+            itemprop="price" content="14500.00">14,500</span> up to 15 attendees</dd>
           <dt>Location</dt>
           <dd>Your premises</dd>
           <dt>Availability</dt>
-          <dd>Private groups only</dd>
+          <dd>from 29 August 2016</dd>
         </dl>
         <p><a href="/cloud/openstack/training/onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>


### PR DESCRIPTION
## Done

Update OpenStack onsite training details as per updated copy doc
Drive by: Increase bottom margin of the first divided div, to make is the same as the bottom padding

## QA

Check that the recent changes to the copy doc have been mirrored in the /cloud/openstack/training/index.html file

## Issue / Card

Card: https://trello.com/c/NULh7MDp
Doc: https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit
