### PR TITLE
Cloud training updates

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -866,7 +866,7 @@ body.cloud-storage {
   }
 
   .row--training__image {
-    position: relative;
+    position: absolute;
     top: -61px;
     right: -20px;
   }

--- a/templates/cloud/openstack/training/index.html
+++ b/templates/cloud/openstack/training/index.html
@@ -22,59 +22,86 @@
     </div>
 </div>
 <div class="row">
-  <ul class="training-list list twelve-col no-bullets">
-    <li>
-      <h2>OpenStack Fundamentals</h2>
-      <div class="equal-height--vertical-divider">
-      <div class="equal-height--vertical-divider__item seven-col">
-      <h3>Classroom training</h3>
-        <p>3-day hands-on classroom-based course that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
-        <p><a class="external" href="https://insights.ubuntu.com/wp-content/uploads/226b/067_CAN_OpenStack_Fundamentals_Flyer_A4_v4_Screen.pdf">Read the course outline (PDF)</a></p>
-      </div>
-      <div class="equal-height--vertical-divider__item five-col last-col">
-        <dl class="course-details" itemscope itemtype="http://schema.org/Product">
-          <dt>Duration</dt>
-          <dd>3 days</dd>
-          <dt>Cost</dt>
-          <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="1950.00">1,950</span> per attendee</dd>
-          <dt>Availability</dt>
-          <dd>Open admissions</dd>
-        </dl>
-        {% comment %}
-        <!-- Example of event layout -->
-        <ul class="five-col no-bullets no-border">
-          <li><a class="external" href="https://insights.ubuntu.com/event/ubuntu-openstack-fundamentals-training-session/">13-15 May 2015, Vancouver, BC, Canada</a></li>
-        </ul>
-        {% endcomment %}
-        <p>Additional sessions are being planned for this year. <a href="/cloud/openstack/training/classroom-contact-us">Register your interest&nbsp;&rsaquo;</a></p>
-      </div>
-    </div>
-    </li>
-    <li>
-      <div class="equal-height--vertical-divider twelve-col">
-      <div class="equal-height--vertical-divider__item seven-col">
-        <h3>Onsite training</h3>
-        <p>3-day hands-on course at your premises for up to 15 students, with a minimum of 8 students required, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
-        <p><a class="external" href="https://assets.ubuntu.com/v1/1f2e7629-Ubuntu_Server_Administration_Training_06.07.16-2-2.pdf">Read the course outline</a></p>
-      </div>
-      <div class="equal-height--vertical-divider__item five-col last-col" itemscope itemtype="http://data-vocabulary.org/Event">
-        <dl class="course-details">
-          <dt>Duration</dt>
-          <dd itemprop="duration">3 days</dd>
-          <dt>Cost</dt>
-          <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span
-            itemprop="price" content="14500.00">14,500</span> up to 15 attendees</dd>
-          <dt>Location</dt>
-          <dd>Your premises</dd>
-          <dt>Availability</dt>
-          <dd>from 29 August 2016</dd>
-        </dl>
-        <p><a href="/cloud/openstack/training/onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
-      </div>
-    </div>
-    </li>
-  </ul>
-</div><!-- /.row -->
+    <ul class="training-list list twelve-col no-bullets">
+        <li>
+            <h2>OpenStack Fundamentals</h2>
+            <div class="equal-height--vertical-divider">
+                <div class="equal-height--vertical-divider__item seven-col">
+                    <h3>Classroom training</h3>
+                    <p>3-day hands-on classroom-based course that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
+                    <p><a class="external" href="https://insights.ubuntu.com/wp-content/uploads/226b/067_CAN_OpenStack_Fundamentals_Flyer_A4_v4_Screen.pdf">Read the course outline (PDF)</a></p>
+                </div>
+                <div class="equal-height--vertical-divider__item five-col last-col">
+                    <dl class="course-details" itemscope itemtype="http://schema.org/Product">
+                        <dt>Duration</dt>
+                        <dd>3 days</dd>
+                        <dt>Cost</dt>
+                        <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="1950.00">1,950</span> per attendee</dd>
+                        <dt>Availability</dt>
+                        <dd>Open admissions</dd>
+                    </dl>
+                    {% comment %}
+                    <!-- Example of event layout -->
+                    <ul class="five-col no-bullets no-border">
+                        <li><a class="external" href="https://insights.ubuntu.com/event/ubuntu-openstack-fundamentals-training-session/">13-15 May 2015, Vancouver, BC, Canada</a></li>
+                    </ul>
+                    {% endcomment %}
+                    <p>Additional sessions are being planned for this year. <a href="/cloud/openstack/training/classroom-contact-us">Register your interest&nbsp;&rsaquo;</a></p>
+                </div>
+            </div>
+        </li>
+        <li>
+            <div class="equal-height--vertical-divider twelve-col">
+                <div class="equal-height--vertical-divider__item seven-col">
+                    <h3>Onsite training</h3>
+                    <p>3-day hands-on course at your premises for up to 15 people that will give you the best introduction for setting up and running your own Ubuntu OpenStack cloud.</p>
+                    <p><a class="external" href="https://insights.ubuntu.com/wp-content/uploads/226b/067_CAN_OpenStack_Fundamentals_Flyer_A4_v4_Screen.pdf">Read the course outline (PDF)</a></p>
+                </div>
+                <div class="equal-height--vertical-divider__item five-col last-col" itemscope itemtype="http://data-vocabulary.org/Event">
+                    <dl class="course-details">
+                        <dt>Duration</dt>
+                        <dd itemprop="duration">3 days</dd>
+                        <dt>Cost</dt>
+                        <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="19500.00">19,500</span> up to 15 attendees</dd>
+                        <dt>Location</dt>
+                        <dd>Your premises</dd>
+                        <dt>Availability</dt>
+                        <dd>Private groups only</dd>
+                    </dl>
+                    <p><a href="/cloud/openstack/training/onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
+                </div>
+            </div>
+        </li>
+    </ul>
+</div>
+<div class="row">
+    <ul class="list twelve-col no-bullets">
+        <li>
+            <h2>Ubuntu Server Administration</h2>
+            <div class="equal-height--vertical-divider twelve-col">
+                <div class="equal-height--vertical-divider__item seven-col">
+                    <h3>Onsite training</h3>
+                    <p>3-day hands-on course at your premises for up to 15 students, with a minimum of 8 students required, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
+                    <p><a class="external" href="https://assets.ubuntu.com/v1/1f2e7629-Ubuntu_Server_Administration_Training_06.07.16-2-2.pdf">Read the course outline (PDF)</a></p>
+                </div>
+                <div class="equal-height--vertical-divider__item five-col last-col" itemscope itemtype="http://data-vocabulary.org/Event">
+                    <dl class="course-details">
+                        <dt>Duration</dt>
+                        <dd itemprop="duration">3 days</dd>
+                        <dt>Cost</dt>
+                        <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500.00">14,500</span> up to 15 attendees</dd>
+                        <dt>Location</dt>
+                        <dd>Your premises</dd>
+                        <dt>Availability</dt>
+                        <dd>from 29 August 2016</dd>
+                    </dl>
+                    <p><a href="/cloud/openstack/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
+                </div>
+            </div>
+        </li>
+    </ul>
+</div>
+
 <div class="row no-border">
   <div class="seven-col">
     <h2>Questions about training?</h2>

--- a/templates/cloud/openstack/training/server-admin-onsite-contact-us.html
+++ b/templates/cloud/openstack/training/server-admin-onsite-contact-us.html
@@ -1,0 +1,100 @@
+{% extends "cloud/base_cloud.html" %}
+
+{% block title %}Onsite training contact us | Ubuntu Cloud{% endblock %}
+
+{% block second_level_nav_items %}
+	{% include "templates/_nav_breadcrumb.html" with section_title="Cloud" subsection_title="Training" page_title="Onsite training contact us" %}
+{% endblock second_level_nav_items %}
+
+{% block head_extra %}
+
+{% endblock head_extra %}
+
+{% block content_container %}
+{% block outer_content %}
+<div class="row no-border">
+    <div class="nine-col"> 
+        <h1>Contact us about our Ubuntu Server Administration training courses</h1>
+        <p>Fill in your details below and a member of our training team will be in touch.</p>
+
+        <script>
+          var profiling = {
+            isEnabled: false,
+            numberOfProfilingFields: 3,
+            alwaysShowFields: [ 'mktDummyEntry']
+          };
+          var mktFormLanguage = 'English'
+        </script>
+
+        <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
+
+        <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1223"> 
+            <fieldset>
+                <h3>About you</h3>
+                <ul class="no-bullets">          
+                    <li class="mktFormReq mktField">    
+                        <label for="FirstName" class="mktoLabel">First name: <span>*</span></label>
+                        <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                    </li>
+                    <li class="mktFormReq mktField">    
+                        <label for="LastName" class="mktoLabel">Last name: <span>*</span></label>
+                        <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                    </li>
+                    <li class="mktFormReq mktField">    
+                        <label for="Company" class="mktoLabel">Company: <span>*</span></label>
+                        <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
+                    </li>
+                    <li class="mktFormReq mktField">    
+                        <label for="Title" class="mktoLabel">Job title: <span>*</span></label>
+                        <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
+                    </li>
+                    <li class="mktFormReq mktField">    
+                        <label for="Email" class="mktoLabel">Email address: <span>*</span></label>
+                        <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+                    </li>
+                    <li class="mktFormReq mktField">    
+                        <label for="Phone" class="mktoLabel">Phone number: <span>*</span></label>
+                        <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+                    </li>
+                </ul>
+            </fieldset>
+            <fieldset>
+                <ul class="no-bullets">    
+                    <li class="mktFormReq mktField">    
+                        <label for="Comments_from_Contact__c" class="mktoLabel">Additional questions and comments <span>*</span></label>
+                        <textarea required id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="5" class="mktoField mktoRequired" maxlength="2000"></textarea>
+                    </li>
+                </ul>
+            </fieldset>
+            <fieldset>
+              <ul class="no-bullets">      
+                <li class="mktField">    
+                    <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox" />
+                    <label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>        
+                </li>
+                <li>
+                    All information provided will be handled in accordance with the Canonical <a href="http://www.ubuntu.com/legal" target="_blank">privacy policy</a>.
+                </li>
+                <li class="mktField">    
+                    <button type="submit" class="mktoButton">Submit</button>
+                </li>
+            </ul>
+            <input type="hidden" name="formid" class="mktoField" value="1223" />
+            <input type="hidden" name="lpId" class="mktoField" value="1973" />
+            <input type="hidden" name="subId" class="mktoField" value="30" />
+            <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335" />
+            <input type="hidden" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/cloud_training_contact-us.html?cr={creative}&amp;kw={keyword}" /><input type="hidden" name="cr" class="mktoField" value="" />
+            <input type="hidden" name="kw" class="mktoField" value="" />
+            <input type="hidden" name="q" class="mktoField" value="" />
+            <input type="hidden" name="returnURL" value="http://www.ubuntu.com/cloud/training/thank-you" />
+            <input type="hidden" name="retURL" value="http://www.ubuntu.com/cloud/training/thank-you" />
+        </fieldset>
+    </form>
+    
+<script  src="{{ ASSET_SERVER_URL }}f97fa297-stateCountry.js"></script>
+<!-- /MARKETO FORM -->
+
+</div>
+</div> 
+{% endblock outer_content %}
+{% endblock content_container %}

--- a/templates/cloud/openstack/training/server-admin-onsite-contact-us.html
+++ b/templates/cloud/openstack/training/server-admin-onsite-contact-us.html
@@ -28,7 +28,7 @@
 
         <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
 
-        <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1223"> 
+        <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1448"> 
             <fieldset>
                 <h3>About you</h3>
                 <ul class="no-bullets">          
@@ -79,8 +79,8 @@
                     <button type="submit" class="mktoButton">Submit</button>
                 </li>
             </ul>
-            <input type="hidden" name="formid" class="mktoField" value="1223" />
-            <input type="hidden" name="lpId" class="mktoField" value="1973" />
+            <input type="hidden" name="formid" class="mktoField" value="1448" />
+            <input type="hidden" name="lpId" class="mktoField" value="2661" />
             <input type="hidden" name="subId" class="mktoField" value="30" />
             <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335" />
             <input type="hidden" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/cloud_training_contact-us.html?cr={creative}&amp;kw={keyword}" /><input type="hidden" name="cr" class="mktoField" value="" />


### PR DESCRIPTION
## Done

Update OpenStack onsite training details as per updated copy doc

## QA

Check that the recent changes to the copy doc have been mirrored in the /cloud/openstack/training/index.html file and make sure the new contact form /cloud/openstack/training/server-admin-onsite-contact-us works

## Issue / Card

Card: https://trello.com/c/NULh7MDp
Doc: https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit
