### PR TITLE
16 04 1 update

### DIFF
--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -14,7 +14,7 @@
     <div class="six-col equal-height__item">
         <h1>A &lsquo;snap&rsquo; is a universal Linux package</h1>
         <p>Snaps work on any distribution or device. Snaps are faster to install, easier to create, safer to run, and they update automatically and transactionally so your app is always fresh and never broken.</p>
-    
+
         <p>The public collection of snaps includes the latest and best apps from GitHub and beyond, so you have the whole world of Linux apps at your fingertips. Take the tour below to experience &lsquo;hello world&rsquo; as a snap, or jump to the <a href="http://snapcraft.io/create/">developer guide</a> to create your own snaps.</p>
     </div>
     <div class="six-col last-col equal-height__item equal-height__align-vertically">
@@ -82,7 +82,7 @@ webdm          0.17                  21   canonical  -</code></pre>
 
             <h3>Release channels &mdash; stable, candidate, beta and edge</h3>
             <p>Developers can publish stable, release candidate, beta and edge versions of a snap, at the same time. This enables them to engage with users who are willing to test upcoming changes, and it enables users to decide how close to the leading edge of development they want to be.</p>
-            
+
             <p>By default, snaps are installed from the stable channel, but there is also a candidate channel which by convention will preview the next stable release, a beta channel and an edge channel.</p>
 
             <pre class="command-line"><code>$ snap refresh hello --channel=beta
@@ -94,9 +94,9 @@ hello  (beta) installed
             <p>Run the beta version of the command:</p>
             <pre class="command-line"><code>$ hello
 Hello, snap padawan!</code></pre>
-            
+
             <p>Note that you could have directly installed hello from the beta channel via:</p>
-            
+
             <pre class="command-line"><code>$ snap install hello --channel-beta</code></pre>
 
             <h3>Developer mode</h3>
@@ -117,7 +117,7 @@ Do you still want to install ‘flubber’? [y/N] N</code></pre>
     <div class="wrapper">
         <div class="seven-col">
             <h2>Popular snaps</h2>
-            <p>If you are running Ubuntu 16.04 LTS, you can try all of this without having to install <code>snapd</code>. Check out snaps on <a class="external" href="https://uappexplorer.com/apps?type=snappy">uappexplorer.com</a> or just use the command line to install any of these great snaps:</p>
+            <p>If you are running Ubuntu {{latest_release_full}}, you can try all of this without having to install <code>snapd</code>. Check out snaps on <a class="external" href="https://uappexplorer.com/apps?type=snappy">uappexplorer.com</a> or just use the command line to install any of these great snaps:</p>
         </div>
 
         <ul class="grid-list twelve-col no-bullets no-margin-bottom">

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -44,7 +44,7 @@
             <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You will need to install a BitTorrent client on your computer in order to enable this download method.</p>
         </div>
         <div class="four-col">
-            <h3 class="external--title"><span>Ubuntu {{latest_release_full}}</span></h3>
+            <h3 class="external--title"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
             <ul class="no-bullets list">
                 <li><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
                 <li><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-i386.iso.torrent">Ubuntu {{latest_release}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -22,7 +22,7 @@
         <div class="twelve-col no-margin-bottom">
             <div class="box box-highlight clearfix equal-height--vertical-divider">
                 <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
-                    <h2>Ubuntu {{lts_release_full}}</h2>
+                    <h2>Ubuntu {{lts_release_full_with_point}}</h2>
                     <p>Download the latest version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support – which means five years of free security and maintenance updates, guaranteed.</p>
                     <p><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="external">Ubuntu {{lts_release_full}} release notes</a></p>
 
@@ -39,7 +39,7 @@
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
                     <p>
-                        <a class="button--primary link-cta-download" href="/download/desktop/contribute/?version=16.04&amp;architecture=amd64">Download</a>
+                        <a class="button--primary link-cta-download" href="/download/desktop/contribute/?version={{lts_release}}&amp;architecture=amd64">Download</a>
                     </p>
                     <ul class="no-bullets">
                         <li><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></li>

--- a/templates/download/how-to-verify.html
+++ b/templates/download/how-to-verify.html
@@ -71,8 +71,8 @@ gpg: keyring `/home/ubuntu/.gnupg/pubring.gpg' created
 gpg: requesting key EFE21092 from hkp server keyserver.ubuntu.com
 gpg: requesting key FBB75451 from hkp server keyserver.ubuntu.com
 gpg: /home/ubuntu/.gnupg/trustdb.gpg: trustdb created
-gpg: key EFE21092: public key "Ubuntu CD Image Automatic Signing Key (2012) &lt;cdimage@ubuntu.com>" imported
-gpg: key FBB75451: public key "Ubuntu CD Image Automatic Signing Key &lt;cdimage@ubuntu.com>" imported
+gpg: key EFE21092: public key "Ubuntu CD Image Automatic Signing Key (2012) &lt;cdimage@ubuntu.com&gt;" imported
+gpg: key FBB75451: public key "Ubuntu CD Image Automatic Signing Key &lt;cdimage@ubuntu.com&gt;" imported
 gpg: no ultimately trusted keys found
 gpg: Total number processed: 2
 gpg:               imported: 2  (RSA: 1)
@@ -105,12 +105,12 @@ uid Ubuntu CD Image Automatic Signing Key (2012) cdimage@ubuntu.com
                     <code>
 $ gpg --verify SHA256SUMS.gpg SHA256SUMS
 gpg: Signature made Fri 25 Mar 04:36:20 2016 GMT using DSA key ID FBB75451
-gpg: Good signature from "Ubuntu CD Image Automatic Signing Key &lt;cdimage@ubuntu.com>" [unknown]
+gpg: Good signature from "Ubuntu CD Image Automatic Signing Key &lt;cdimage@ubuntu.com&gt;" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
 Primary key fingerprint: C598 6B4F 1257 FFA8 6632  CBA7 4618 1433 FBB7 5451
 gpg: Signature made Fri 25 Mar 04:36:20 2016 GMT using RSA key ID EFE21092
-gpg: Good signature from "Ubuntu CD Image Automatic Signing Key (2012) &lt;cdimage@ubuntu.com>" [unknown]
+gpg: Good signature from "Ubuntu CD Image Automatic Signing Key (2012) &lt;cdimage@ubuntu.com&gt;" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
 Primary key fingerprint: 8439 38DF 228D 22F7 B374  2BC0 D94A A3F0 EFE2 1092</code>

--- a/templates/download/how-to-verify.html
+++ b/templates/download/how-to-verify.html
@@ -45,7 +45,7 @@
             Download sums
             </h3>
             <p>Download the SHA256SUMS and SHA256SUMS.gpg files from any of the mirrors and put them in the same directory.</p>
-            <p><a href="http://releases.ubuntu.com/{{ lts_release }}">Download sums and signature for {{ lts_release_full }}&nbsp;&rsaquo;</a></p>
+            <p><a href="http://releases.ubuntu.com/{{lts_release_no_point}}">Download sums and signature for Ubuntu {{ lts_release_full_with_point }}&nbsp;&rsaquo;</a></p>
             <img src="https://assets.ubuntu.com/v1/f1cce1af-verify-1-releases.png" alt="Verify release screenshot" />
         </li>
 
@@ -71,8 +71,8 @@ gpg: keyring `/home/ubuntu/.gnupg/pubring.gpg' created
 gpg: requesting key EFE21092 from hkp server keyserver.ubuntu.com
 gpg: requesting key FBB75451 from hkp server keyserver.ubuntu.com
 gpg: /home/ubuntu/.gnupg/trustdb.gpg: trustdb created
-gpg: key EFE21092: public key "Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>" imported
-gpg: key FBB75451: public key "Ubuntu CD Image Automatic Signing Key <cdimage@ubuntu.com>" imported
+gpg: key EFE21092: public key "Ubuntu CD Image Automatic Signing Key (2012) &lt;cdimage@ubuntu.com>" imported
+gpg: key FBB75451: public key "Ubuntu CD Image Automatic Signing Key &lt;cdimage@ubuntu.com>" imported
 gpg: no ultimately trusted keys found
 gpg: Total number processed: 2
 gpg:               imported: 2  (RSA: 1)
@@ -139,7 +139,7 @@ Primary key fingerprint: 8439 38DF 228D 22F7 B374  2BC0 D94A A3F0 EFE2 1092</cod
             <pre class="twelve-col"><code>$ sha256sum.exe -c SHA256SUMS</code></pre>
 
             <p>The output you want will look similar to the following:</p>
-            <pre class="twelve-col"><code>ubuntu-16.04-desktop-amd64.iso: OK</code></pre>
+            <pre class="twelve-col"><code>ubuntu-{{lts_release}}-desktop-amd64.iso: OK</code></pre>
 
             <p>If you get no results (or any result other than that shown above) you will need to check your download again.</p>
         </li>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -13,7 +13,7 @@
     <div class="strip-inner-wrapper">
         <div class="eight-col">
             <h1>Ubuntu Server for ARM</h1>
-            <p>Ubuntu 16.04 LTS includes support for the very latest ARM-based server systems powered by certified 64-bit processors.</p>
+            <p>Ubuntu {{lts_release_full_with_point}} includes support for the very latest ARM-based server systems powered by certified 64-bit processors.</p>
             <p>Develop and test using over 50,000 software packages and runtimes &mdash; including Go, Java, Javascript, PHP, Python and Ruby &mdash; and deploy at scale using our complete scale-out management suite including MAAS and Juju. Ubuntu delivers server-grade performance on ARM, while fully retaining the reliable and familiar Ubuntu experience.</p>
             <!-- p><a class="external" href="http://www.ubuntu.com/certification/soc/">See all certified ARM systems</a></p -->
         </div>
@@ -22,13 +22,13 @@
                 <div class="equal-height--vertical-divider__item six-col">
                     <h3>Ubuntu Server</h3>
                     <p>This is the iso image of the Ubuntu Server installer.</p>
-                    <p><a href="http://ports.ubuntu.com/ubuntu-ports/dists/xenial/main/installer-arm64/current/images/netboot/mini.iso" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '16.04', 'eventValue' : undefined });">Download 16.04 LTS</a></p>
+                    <p><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-arm64.iso" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
                     <p><a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a></p>
                 </div>
                 <div class="equal-height--vertical-divider__item six-col last-col">
                     <h3>Ubuntu netboot</h3>
                     <p>This installer lets you install Ubuntu over the network.</p>
-                    <p><a href="http://ports.ubuntu.com/ubuntu-ports/dists/xenial/main/installer-arm64/current/images/netboot/netboot.tar.gz" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '16.04', 'eventValue' : undefined });">Download 16.04 LTS</a></p>
+                    <p><a href="http://cdimage/releases/{{lts_release}}/release" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
                     <p><a href="https://help.ubuntu.com/community/Installation/Netboot">Learn about netboot images&nbsp;&rsaquo;</a></p>
                 </div>
             </div>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -28,7 +28,7 @@
                 <div class="equal-height--vertical-divider__item six-col last-col">
                     <h3>Ubuntu netboot</h3>
                     <p>This installer lets you install Ubuntu over the network.</p>
-                    <p><a href="http://cdimage/releases/{{lts_release}}/release" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
+                    <p><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
                     <p><a href="https://help.ubuntu.com/community/Installation/Netboot">Learn about netboot images&nbsp;&rsaquo;</a></p>
                 </div>
             </div>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -19,7 +19,7 @@
         <div class="twelve-col no-margin-bottom">
             <div class="box box-highlight clearfix equal-height--vertical-divider">
                 <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
-                    <h2>Ubuntu Server {{lts_release_full}}</h2>
+                    <h2>Ubuntu Server {{lts_release_full_with_point}}</h2>
                     <p>The long-term support version of Ubuntu Server, including the {{openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
                     <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release_full}} release notes</a></p>
                 </div>
@@ -49,7 +49,7 @@
             <div class="six-col box">
                 <h3>Ubuntu for POWER8</h3>
                 <p>Ubuntu is now available on the IBM POWER8 platform, bringing the entire Ubuntu and OpenStack ecosystem to IBM POWER8</p>
-                <p><a href="/download/server/power8">Get Ubuntu {{latest_release}} for POWER8&nbsp;&rsaquo;</a></p>
+                <p><a href="/download/server/power8">Get Ubuntu for POWER8&nbsp;&rsaquo;</a></p>
             </div>
             <div class="six-col box last-col">
                 <h3>Ubuntu for IBM LinuxONE</h3>

--- a/templates/download/server/linuxone.html
+++ b/templates/download/server/linuxone.html
@@ -23,13 +23,13 @@
             <div class="twelve-col no-margin-bottom">
                 <div class="box box-highlight clearfix equal-height--vertical-divider">
                     <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
-                        <h2>Ubuntu Server {{lts_release_full}}</h2>
-                        <p>IBM LinuxONE and z&nbsp;Systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM&rsquo;s enterprise customers unprecedented performance, security and resiliency. Ubuntu {{lts_release_full}} is now available to all IBM LinuxOne and z Systems customers.</p>
+                        <h2>Ubuntu Server {{lts_release_full_with_point}}</h2>
+                        <p>IBM LinuxONE and z&nbsp;Systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM&rsquo;s enterprise customers unprecedented performance, security and resiliency. Ubuntu {{lts_release_full_with_point}} is now available to all IBM LinuxOne and z Systems customers.</p>
 
-                        <p>Ubuntu {{lts_release_full}} for IBM LinuxONE and z&nbsp;Systems is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
+                        <p>Ubuntu {{lts_release_full_with_point}} for IBM LinuxONE and z&nbsp;Systems is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
 
                         <p>Your use of Ubuntu on z&nbsp;Systems and LinuxONE in production constitutes <a href="http://www.ubuntu.com/legal/short-terms">acceptance of these terms</a>.</p>
-                        
+
                         <p>For questions about Ubuntu Advantage for LinuxONE and z Systems, please call us +44 (0) 207 630 2406 or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
                     </div>
                     <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">

--- a/templates/download/server/power8.html
+++ b/templates/download/server/power8.html
@@ -23,14 +23,14 @@
                     <h4>Ubuntu Server</h4>
                     <ul class="no-bullets">
                         <li><a href="http://cdimage.ubuntu.com/releases/14.04.4/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '14.04.4', 'eventValue' : undefined });">14.04.4 &nbsp;&rsaquo;</a></li>
-                        <li><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full}}&nbsp;&rsaquo;</a></li>
+                        <li><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}}&nbsp;&rsaquo;</a></li>
                     </ul>
                 </div>
                 <div class="six-col last-col">
                     <h4>Netboot image</h4>
                     <ul class="no-bullets">
                         <li><a href="http://cdimage.ubuntu.com/netboot/14.04.4/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '14.04.4', 'eventValue' : undefined });">14.04.4&nbsp;&rsaquo;</a></li>
-                        <li><a href="http://ports.ubuntu.com/ubuntu-ports/dists/xenial/main/installer-ppc64el/current/images/netboot/{{lts_release}}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full}}&nbsp;&rsaquo;</a></li>
+                        <li><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}}&nbsp;&rsaquo;</a></li>
                     </ul>
                 </div>
             </div><!-- /.box -->

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -12,7 +12,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
 {% endblock second_level_nav_items %}
 
 {% block head_extra %}
-<meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-s390x.iso">
+<meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/{{lts_release}}/release/ubuntu-{{lts_release}}-server-s390x.iso">
 {% endblock %}
 
 {% block content %}
@@ -21,9 +21,9 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
     <div class="strip-inner-wrapper">
         <div class="six-col">
             <h1>Thanks for downloading Ubuntu for LinuxONE and z&nbsp;Systems</h1>
-            <p>Thank you for downloading Ubuntu {{lts_release_full}} for IBM LinuxONE and z Systems. Your ISO download should start automatically.</p>
+            <p>Thank you for downloading Ubuntu {{lts_release_full_with_point}} for IBM LinuxONE and z Systems. Your ISO download should start automatically.</p>
             <p>If it doesn&rsquo;t, or for alternative options <a href="http://cdimage.ubuntu.com/releases/xenial/release ">visit the download page</a>.</p>
-            <p>Ubuntu 16.04 LTS for IBM LinuxONE and z Systems is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
+            <p>Ubuntu {{lts_release_full_with_point}} for IBM LinuxONE and z Systems is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, 24x7 Ubuntu Advantage Advanced support services and regular security and reliability fixes from Canonical.</p>
             <p>Your use of Ubuntu on z Systems and LinuxONE in production constitutes <a href="http://www.ubuntu.com/legal/short-terms">acceptance of these terms</a>.</p>
             <p>For questions about Ubuntu Advantage for LinuxONE and z Systems, please call us +44 (0) 207 630 2406 or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
         </div>

--- a/templates/download/ubuntu-kylin.html
+++ b/templates/download/ubuntu-kylin.html
@@ -18,8 +18,8 @@
         <div class="twelve-col no-margin-bottom">
             <div class="box box-highlight clearfix equal-height--vertical-divider">
             <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
-                <h2>Ubuntu Kylin {{lts_release_full}}</h2>
-                <p>Download the long-term support edition of Ubuntu Kylin {{lts_release_full}} ISO image file. To install Ubuntu Kylin, burn the image file on a DVD or create a bootable USB disk.</p>
+                <h2>Ubuntu Kylin {{lts_release_full_with_point}}</h2>
+                <p>Download the long-term support edition of Ubuntu Kylin {{lts_release_full_with_point}} ISO image file. To install Ubuntu Kylin, burn the image file on a DVD or create a bootable USB disk.</p>
             </div>
             <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom">
                 <form class="form-download gap-from-top lts" action="http://cdimage.ubuntu.com/ubuntukylin/releases/{{lts_release}}/release/ubuntukylin-{{lts_release}}-desktop-amd64.iso" method="get">

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -3,7 +3,7 @@
 
 {# Release versions - update as appropriate #}
 {% with latest_release_name="XenialXerus" latest_release="16.04.1" latest_release_full='16.04 <abbr title="long-term support">LTS</abbr>' %}
-{% with lts_release_name="XenialXerus" lts_release="16.04.1" lts_release_full='16.04 <abbr title="long-term support">LTS</abbr>' lts_release_with_point="16.04.1" lts_release_full_with_point='16.04.1 <abbr title="long-term support">LTS</abbr>' %}
+{% with lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.1" lts_release_full='16.04 <abbr title="long-term support">LTS</abbr>' lts_release_with_point="16.04.1" lts_release_full_with_point='16.04.1 <abbr title="long-term support">LTS</abbr>' %}
 {% with openstack_version="Mitaka" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,8 +2,8 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="XenialXerus" latest_release="16.04" latest_release_full='16.04 <abbr title="long-term support">LTS</abbr>' %}
-{% with lts_release_name="XenialXerus" lts_release="16.04" lts_release_full='16.04 <abbr title="long-term support">LTS</abbr>' %}
+{% with latest_release_name="XenialXerus" latest_release="16.04.1" latest_release_full='16.04 <abbr title="long-term support">LTS</abbr>' %}
+{% with lts_release_name="XenialXerus" lts_release="16.04.1" lts_release_full='16.04 <abbr title="long-term support">LTS</abbr>' lts_release_with_point="16.04.1" lts_release_full_with_point='16.04.1 <abbr title="long-term support">LTS</abbr>' %}
 {% with openstack_version="Mitaka" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

* added new variables to base for point release info as we don't want that everywhere, just in download sections
* updated links per Adam Conrad
* updated download pages to use variables

## QA

1. go to the download pages and see that it says 16.04.1 when talking about downloads (no documents) and see that the urls look ok... they will not work until release. [demo site](http://www.ubuntu.com-16-04-1_update.demo.haus/download)


## Issue / Card

[trello card](https://trello.com/c/d4WWz3zS)
