### PR TITLE
update arm netboot link

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -28,7 +28,7 @@
                 <div class="equal-height--vertical-divider__item six-col last-col">
                     <h3>Ubuntu netboot</h3>
                     <p>This installer lets you install Ubuntu over the network.</p>
-                    <p><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
+                    <p><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM netboot download', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">Download Ubuntu {{lts_release_full_with_point}}</a></p>
                     <p><a href="https://help.ubuntu.com/community/Installation/Netboot">Learn about netboot images&nbsp;&rsaquo;</a></p>
                 </div>
             </div>


### PR DESCRIPTION
## Done

* updated arm netboot image

## QA

1. go to /download/server/arm and see that netboot link goes to:  http://cdimage.ubuntu.com/netboot/16.04.1

