### PR TITLE
Fix bug 1602014 - phone/developers 404

### DIFF
--- a/templates/phone/developers.html
+++ b/templates/phone/developers.html
@@ -49,7 +49,7 @@
       <h2>Build more than just an app</h2>
       <p>By leveraging scopes, your content and services become an integral part of the default phone experience &mdash; and at a fraction of the cost of developing and maintaining a traditional app. It&rsquo;s never been this easy to develop a mobile&nbsp;experience.</p>
       <p>The Ubuntu SDK also support mainstream HTML5 apps beautifully, while a rich Qt/QML based native app environment can be used to develop deeper experiences, like&nbsp;games.</p>
-      <p><a class="external" href="https://developer.ubuntu.com/en/apps/">Visit developer.ubuntu.com</a></p>
+      <p><a class="external" href="https://developer.ubuntu.com/en/phone/apps/">Visit developer.ubuntu.com</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Fix bug 1602014 - phone/developers 404

## QA

Make sure that the link 'Visit developer.ubuntu.com’ at /phone/developers in the 'Build more than just an app’ section goes to https://developer.ubuntu.com/en/phone/apps/ and not the current 404 as is on live.

## Issue / Card

Bug: https://bugs.launchpad.net/ubuntu-website-content/+bug/1602014
