### PR TITLE
Fix bug 1586588 - 404 on phone developers

### DIFF
--- a/templates/phone/developers.html
+++ b/templates/phone/developers.html
@@ -152,13 +152,8 @@
         </div>
         <div class="eight-col">
             <h2>Using Ubuntu on your favourite phone</h2>
-            <p>Ubuntu is entirely open source, so anyone can port it onto a compatible
-            phone. Whether you’re a hardcore kernel developer or just a tech enthusiast
-            in a ROM-flashing mood, you’ll find plenty of like-minded people to help
-            in the Ubuntu community. And if you have a phone with HDMI-out,
-            you can use Ubuntu to turn it into a convergent device, running
-            full PC apps when you connect it to a screen, mouse and keyboard. </p>
-            <p><a href="https://developer.ubuntu.com/en/start/ubuntu-for-devices">Learn how to get involved&nbsp;&rsaquo;</a></p>
+            <p>Ubuntu is entirely open source, so anyone can port it onto a compatible phone. Whether you’re a hardcore kernel developer or just a tech enthusiast in a ROM-flashing mood, you&rsquo;ll find plenty of like-minded people to help in the Ubuntu community. And if you have a phone with HDMI-out, you can use Ubuntu to turn it into a convergent device, running full PC apps when you connect it to a screen, mouse and keyboard.</p>
+            <p><a class="external" href="https://developer.ubuntu.com/en/phone/devices/">Learn how to get involved</a></p>
         </div>
     </div>
 </div><!-- /.row -->


### PR DESCRIPTION
## Done

On /phone/developers in the last section 'Using Ubuntu on your favourite phone', the 'Learn how to get involved' link 404s

## QA

Make sure that the link 'Learn how to get involved’ at /phone/developers in the 'Using Ubuntu on your favourite phone’ section goes to https://developer.ubuntu.com/en/phone/devices/ and not the current 404 as is on live.


## Issue / Card

Bug: https://bugs.launchpad.net/ubuntu-website-content/+bug/1586588
