### PR TITLE
update link to desktop documentation

### DIFF
--- a/templates/shared/contextual_footers/_download_desktop_guide.html
+++ b/templates/shared/contextual_footers/_download_desktop_guide.html
@@ -1,3 +1,3 @@
 <h3 class="contextual-footer__title">Ubuntu desktop guide</h3>
 <p class="contextual-footer__text">Read the official Ubuntu desktop documentation.</p>
-<p class="contextual-footer__text"><a class="external" href="https://help.ubuntu.com/{{lts_release}}/index.html" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c', 'eventLabel' : 'Ubuntu desktop guide', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>
+<p class="contextual-footer__text"><a class="external" href="https://help.ubuntu.com/stable/ubuntu-help" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'help.u.c', 'eventLabel' : 'Ubuntu desktop guide', 'eventValue' : undefined });">Ubuntu {{lts_release_full}} documentation</a></p>


### PR DESCRIPTION
## Done

Updated link to official desktop documentation

## QA

1. go to /download/desktop/thank-you?version=16.04.1&architecture=amd64
2. see that the contextual footer link to the documentation now goes to https://help.ubuntu.com/stable/ubuntu-help


## Issue / Card

Fixes #776 and [bug 1606045](https://bugs.launchpad.net/ubuntu-docs/+bug/1606045)


