### PR TITLE
add 16.04 to download images instructions

### DIFF
--- a/templates/download/cloud/install-openstack-with-autopilot.html
+++ b/templates/download/cloud/install-openstack-with-autopilot.html
@@ -88,7 +88,7 @@
                     </p>
                     <ul class="no-bullets">
                         <li>Login to the MAAS UI at http://&lt;maas.ip&gt;/MAAS/</li>
-                        <li>Go to the &ldquo;Images&rdquo; tab and import disk images for &ldquo;14.04 LTS amd64&rdquo;</li>
+                        <li>Go to the &ldquo;Images&rdquo; tab and import disk images for both &ldquo;14.04 LTS amd64&rdquo; and &ldquo;16.04 LTS amd64&rdquo;</li>
                         <li>In your MAAS user&rsquo;s settings (top-right corner) add your personal public SSH key so you can later log into the nodes</li>
                         <li>Go to the &ldquo;Networks&rdquo; tab and for each of the networks auto-created, click &ldquo;Edit network&rdquo; to add the default gateway and DNS server details</li>
                     </ul>


### PR DESCRIPTION
## Done

* added 16.04 image to list of downloads in step 3 per Landscape team request

## QA

1. go to /download/cloud/install-openstack-with-autopilot
2. see that step 3 now says "Go to the “Images” tab and import disk images for both “14.04 LTS amd64” and “16.04 LTS amd64”" per the [copy doc](https://docs.google.com/document/d/1aoRSMJkGsAacGoLlIuzPg3J-630OVhAEORNEa2U5UJ8/edit)

## Issue / Card

[trello card](https://trello.com/c/4iVcibxw)
