### PR TITLE
782 - fix typo on release chart

### DIFF
--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -21,7 +21,7 @@
 		<p>Standard Ubuntu releases are supported for 9 months and Ubuntu LTS (long-term support) releases are supported for five years on both the desktop and the server. During that time, there will be security fixes and other critical updates. The Ubuntu support lifecycle is as follows:</p>
 	</div>
 	<div class="twelve-col">
-		<img src="{{ ASSET_SERVER_URL }}ac31b45e-release-chart-desktop-big.png?w=800" width="800" alt="Ubuntu Desktop release cycle, 5 year long-term support" class="not-for-small" />
+		<img src="{{ ASSET_SERVER_URL }}65d114f8-release-chart-desktop.png?w=800" width="800" alt="Ubuntu Desktop release cycle, 5 year long-term support" class="not-for-small" />
 		<table class="for-small">
 			<thead>
 				<tr><th>Release</th><th>Released</th><th>End of life</th></tr>

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -2,7 +2,7 @@
     <div class="seven-col equal-height__item equal-height__align-vertically">
         <div>
             <h3>Ubuntu release cycle</h3>
-            <img src="{{ ASSET_SERVER_URL }}42711c45-release-chart-desktop.png?w=540" srcset="{{ ASSET_SERVER_URL }}42711c45-release-chart-desktop.png?w=431 880w, {{ ASSET_SERVER_URL }}42711c45-release-chart-desktop.png?w=305 980w, {{ ASSET_SERVER_URL }}42711c45-release-chart-desktop.png?w=540 1064w" alt="Ubuntu Desktop release cycle, 5 year long-term support" />
+            <img src="{{ ASSET_SERVER_URL }}65d114f8-release-chart-desktop.png?w=540" srcset="{{ ASSET_SERVER_URL }}65d114f8-release-chart-desktop.png?w=431 880w, {{ ASSET_SERVER_URL }}65d114f8-release-chart-desktop.png?w=305 980w, {{ ASSET_SERVER_URL }}65d114f8-release-chart-desktop.png?w=540 1064w" alt="Ubuntu Desktop release cycle, 5 year long-term support" />
         </div>
     </div>
     <div class="five-col last-col equal-height__item equal-height__align-vertically">
@@ -13,6 +13,6 @@
     {% endif %}
     {% if level_1 == 'server' %}
         <p>Long-term support (LTS) releases of Ubuntu Server are supported by Canonical for five years. Every six months, interim releases bring new features, while hardware enablement updates add support for the latest machines to all supported LTS releases. </p>
-    {% endif %}    
+    {% endif %}
     </div><!-- /.four-col -->
 </div><!-- /.row -->

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -2,7 +2,7 @@
     <div class="seven-col equal-height__item equal-height__align-vertically">
         <div>
             <h3>Ubuntu release cycle</h3>
-            <img src="{{ ASSET_SERVER_URL }}65d114f8-release-chart-desktop.png?w=540" srcset="{{ ASSET_SERVER_URL }}65d114f8-release-chart-desktop.png?w=431 880w, {{ ASSET_SERVER_URL }}65d114f8-release-chart-desktop.png?w=305 980w, {{ ASSET_SERVER_URL }}65d114f8-release-chart-desktop.png?w=540 1064w" alt="Ubuntu Desktop release cycle, 5 year long-term support" />
+            <img src="{{ ASSET_SERVER_URL }}1d30651f-release-chart-desktop_small.png?w=540" srcset="{{ ASSET_SERVER_URL }}1d30651f-release-chart-desktop_small.png?w=431 880w, {{ ASSET_SERVER_URL }}1d30651f-release-chart-desktop_small.png?w=305 980w, {{ ASSET_SERVER_URL }}1d30651f-release-chart-desktop_small.png?w=540 1064w" alt="Ubuntu Desktop release cycle, 5 year long-term support" />
         </div>
     </div>
     <div class="five-col last-col equal-height__item equal-height__align-vertically">


### PR DESCRIPTION
## Done

* fixed desktop/server release chart typo on work 'maintenance'

## QA

1. go to /desktop/enterprise and see the chart has the correct spelling
2. go to /server and see the chart has the correct spelling
3. go to /info/release-end-of-life and see the chart has the correct spelling
 
## Issue / Card

Fixed #782 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/17246951/54572a10-5587-11e6-9ced-e17a7eaf0459.png)
