### PR TITLE
Update download section for 14.04.5

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -53,12 +53,12 @@
             </ul>
         </div><!-- /.four-col -->
         <div class="four-col">
-            <h3 class="external--title"><span>Ubuntu 14.04.4 LTS</span></h3>
+            <h3 class="external--title"><span>Ubuntu 14.04.5 LTS</span></h3>
             <ul class="no-bullets list">
-                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-desktop-amd64.iso.torrent">Ubuntu 14.04.4 Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-desktop-i386.iso.torrent">Ubuntu 14.04.4 Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-server-amd64.iso.torrent">Ubuntu 14.04.4 Server (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-server-i386.iso.torrent">Ubuntu 14.04.4 Server (32-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-amd64.iso.torrent">Ubuntu 14.04.5 Desktop (64-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-i386.iso.torrent">Ubuntu 14.04.5 Desktop (32-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso.torrent">Ubuntu 14.04.5 Server (64-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-i386.iso.torrent">Ubuntu 14.04.5 Server (32-bit)&nbsp;&rsaquo;</a></li>
             </ul>
         </div><!-- /.four-col -->
         <div class="four-col last-col">

--- a/templates/download/server/power8.html
+++ b/templates/download/server/power8.html
@@ -22,14 +22,14 @@
                 <div class="six-col">
                     <h4>Ubuntu Server</h4>
                     <ul class="no-bullets">
-                        <li><a href="http://cdimage.ubuntu.com/releases/14.04.4/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '14.04.4', 'eventValue' : undefined });">14.04.4 &nbsp;&rsaquo;</a></li>
+                        <li><a href="http://cdimage.ubuntu.com/releases/14.04.5/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5 &nbsp;&rsaquo;</a></li>
                         <li><a href="http://cdimage.ubuntu.com/releases/{{lts_release}}/release/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 server', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}}&nbsp;&rsaquo;</a></li>
                     </ul>
                 </div>
                 <div class="six-col last-col">
                     <h4>Netboot image</h4>
                     <ul class="no-bullets">
-                        <li><a href="http://cdimage.ubuntu.com/netboot/14.04.4/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '14.04.4', 'eventValue' : undefined });">14.04.4&nbsp;&rsaquo;</a></li>
+                        <li><a href="http://cdimage.ubuntu.com/netboot/14.04.5/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '14.04.5', 'eventValue' : undefined });">14.04.5&nbsp;&rsaquo;</a></li>
                         <li><a href="http://cdimage.ubuntu.com/netboot/{{lts_release}}/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'POWER8 netboot', 'eventLabel' : '{{lts_release}}', 'eventValue' : undefined });">{{lts_release_full_with_point}}&nbsp;&rsaquo;</a></li>
                     </ul>
                 </div>
@@ -42,7 +42,7 @@
     <div class="strip-inner-wrapper equal-height">
         <div class="six-col box clearfix">
             <h3>Ubuntu 14.04 for IBM POWER8</h3>
-            <p>Ubuntu 14.04 brings with it, for the first time, support for IBM POWER8 including our MAAS provisioning, Juju cloud orchestration, Landscape systems management and Ubuntu OpenStack. Ubuntu 14.04.4 adds CAPI and PowerNV support.</p>
+            <p>Ubuntu 14.04 brings with it, for the first time, support for IBM POWER8 including our MAAS provisioning, Juju cloud orchestration, Landscape systems management and Ubuntu OpenStack. Ubuntu 14.04.5 adds CAPI and PowerNV support.</p>
         </div>
         <div class="six-col box clearfix last-col">
             <h3>Ubuntu {{latest_release_full}} for IBM POWER8</h3>


### PR DESCRIPTION
This is a simple `rgrep -l 14.04.4 | xargs sed -i -e 's/14.04.4/14.04.5/g'` and looks basically correct on visual examination.

I'll need this rolled out on Thursday sometime after the 14.04.5 release announcement (timing isn't critical, as none of these links are references from the announcement, unlike with the current LTS/non-LTS). 