### PR TITLE
remove heap analytics code

### DIFF
--- a/templates/cloud/base_cloud.html
+++ b/templates/cloud/base_cloud.html
@@ -1,6 +1,5 @@
 {% extends "templates/base.html" %}
 {% block meta_keywords %}cloud, OpenStack, Orchestration, Deployment, Juju, Public cloud, Private cloud, Virtualisation{% endblock %}
-{% block head_extra %}{% include "shared/_analytics_heap.html" %}{% endblock %}
 
 {% block outer_content %}
     {% block content %}{% endblock %}

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -339,8 +339,6 @@
 {% block head_extra %}
 <script src="{{ ASSET_SERVER_URL }}c954db4a-jfeed_prm.js"></script>
 
-{% include "shared/_analytics_heap.html" %}
-
 <style type="text/css">
   @keyframes fadeIn {
     0% {

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -4,8 +4,6 @@
 
 {% block extra_body_class %}download-cloud-home{% endblock %}
 
-{% block head_extra %}{% include "shared/_analytics_heap.html" %}{% endblock %}
-
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
     {% include "templates/_nav_breadcrumb.html" with section_title="Download" page_title="Cloud"  %}

--- a/templates/download/cloud/install-autopilot-testdrive.html
+++ b/templates/download/cloud/install-autopilot-testdrive.html
@@ -9,9 +9,6 @@
 {% block extra_body_class %}
     download-help
 {% endblock %}
-{% block head_extra %}
-    {% include "shared/_analytics_heap.html"%}
-{% endblock %}
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
     {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Cloud" page_title="Test drive Canonical's OpenStack Autopilot" %}

--- a/templates/download/cloud/install-openstack-with-autopilot.html
+++ b/templates/download/cloud/install-openstack-with-autopilot.html
@@ -6,8 +6,6 @@
 
 {% block extra_body_class %}download-help{% endblock %}
 
-{% block head_extra %}{% include "shared/_analytics_heap.html" %}{% endblock %}
-
 {% block second_level_nav_items %}
     <div class="strip-inner-wrapper">
         {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Cloud" page_title="Installing Ubuntu Cloud"  %}

--- a/templates/download/cloud/thank-you.html
+++ b/templates/download/cloud/thank-you.html
@@ -3,8 +3,6 @@
 {% block title %}Thank you | Download{% endblock %}
 {% block extra_body_class %}download-thankyou{% endblock %}
 
-{% block head_extra %}{% include "shared/_analytics_heap.html" %}{% endblock %}
-
 {% block second_level_nav_items %}
 {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Cloud" page_title="Thank you"  %}
 {% endblock second_level_nav_items %}

--- a/templates/internet-of-things/base_things.html
+++ b/templates/internet-of-things/base_things.html
@@ -1,6 +1,5 @@
 {% extends "templates/base.html" %}
 {% block meta_keywords %}snappy, Core Ubuntu, Internet of Things, IoT{% endblock %}
-{% block head_extra %}{% include "shared/_analytics_heap.html" %}{% endblock %}
 
 {% block outer_content %}
     {% block content %}{% endblock %}

--- a/templates/shared/_analytics_heap.html
+++ b/templates/shared/_analytics_heap.html
@@ -1,6 +1,0 @@
-<!-- Heap Analytics -->
-<script type="text/javascript">
-    window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var n=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(n?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var o=document.getElementsByTagName("script")[0];o.parentNode.insertBefore(a,o);for(var r=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["clearEventProperties","identify","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=r(p[c])};
-    heap.load("3280028620");
- </script>
-<!-- end Heap Analytics -->


### PR DESCRIPTION
## Done

* Thibaut mentioned they weren't using heap anymore, so we should remove it from the site as it will slow things down for users

## QA

* removed heap partial and all references to it in the site
* see that there are no other heap references

## Issue / Card

[trello card](https://trello.com/c/0IqszWKY)
