### PR TITLE
update training avaible date

### DIFF
--- a/templates/cloud/openstack/training/index.html
+++ b/templates/cloud/openstack/training/index.html
@@ -93,7 +93,7 @@
                         <dt>Location</dt>
                         <dd>Your premises</dd>
                         <dt>Availability</dt>
-                        <dd>from 29 August 2016</dd>
+                        <dd>from 10 October 2016</dd>
                     </dl>
                     <p><a href="/cloud/openstack/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
                 </div>


### PR DESCRIPTION
## Done

* updated training start date to 10 Oct
* updated the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit)

## QA

1. go to /cloud/openstack/training and see that the start date for server training is now 10 October 2016

## Issue / Card

[trello card](https://trello.com/c/nmp8JJLK)