### PR TITLE
update CIO takeunder link

### DIFF
--- a/templates/takeovers/takeunders/_cio-report.html
+++ b/templates/takeovers/takeunders/_cio-report.html
@@ -3,7 +3,7 @@
         <img class="featured__image featured--right__image not-for-small" src="{{ ASSET_SERVER_URL }}3aa7e9a6-picto-articles-white.svg" width="150" alt="" />
     </div>
     <div class="six-col prepend-one append-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/1KPKrJ" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'CIO report takeunder', 'CIO&rsquo;s guide to SDN, NFV and VNF']);">CIO&rsquo;s guide to <abbr title="Software-Defined Networking">SDN</abbr>, <abbr title="Network Functions Virtualization">NFV</abbr> and <abbr title="Virtualised Network Function">VNF</abbr>&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/hSzepr" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'CIO report takeunder', 'CIO&rsquo;s guide to SDN, NFV and VNF']);">CIO&rsquo;s guide to <abbr title="Software-Defined Networking">SDN</abbr>, <abbr title="Network Functions Virtualization">NFV</abbr> and <abbr title="Virtualised Network Function">VNF</abbr>&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Download the eBook and learn about the benefits and solutions for software-enabled networking.</p>
     </div>
 </div>


### PR DESCRIPTION
## Done

* fixed link on CIO takeunder

## QA

1. go to homepage and see that the CIO takeunder goes to the [correct page](https://pages.ubuntu.com/CIO_Report.html??utm_source=ubuntu.com&utm_medium=takeunder&utm_campaign=eBook-CIO%27s-Guide&)

## Issue / Card

[trello card](https://trello.com/c/yTMoUnDx)