### PR TITLE
add ctas for new buy.u.c shop

### DIFF
--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -14,6 +14,7 @@
         <h1>Ubuntu for enterprise</h1>
         <p class="intro">On the desktop, Ubuntu has been widely adopted by small and large enterprises because of its ease of use, speed, apps, security model, management tools and low cost of ownership.</p>
         <p><a href="/desktop/contact-us" class="button--primary">Contact us</a></p>
+        <p><a href="https://buy.ubuntu.com" class="external">Buy Ubuntu Advantage</a></p>
         {% include "desktop/shared/_share-this.html" with tweet="See how #Ubuntu desktop OS might benefit your business" %}
     </div>
 </div>

--- a/templates/management/index.html
+++ b/templates/management/index.html
@@ -18,6 +18,7 @@
   <h1>Support and management tools</h1>
     <div class="seven-col no-margin-bottom">
         <p>Ubuntu Advantage is the commercial support package from Canonical. It includes Landscape, the Ubuntu systems management tool, for running desktop, server and public cloud deployments, or building and managing private OpenStack clouds.</p>
+        <p><a href="https://buy.ubuntu.com" class="button--primary"><span class="external">Visit the Ubuntu Advantage store</span></a></p>
         <p><a href="/management/contact-us">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div><!-- /.six-col -->
     <div class="five-col last-col align-center">

--- a/templates/management/ubuntu-advantage.html
+++ b/templates/management/ubuntu-advantage.html
@@ -15,10 +15,8 @@
   <h1>Ubuntu Advantage</h1>
   <div class="eight-col">
     <p>Ubuntu Advantage is the professional package of tooling, technology and expertise from Canonical, helping organisations around the world to manage their Ubuntu deployments. It includes access to Landscape, the systems management tool for using Ubuntu at scale, as well as 24x7 telephone and web support and the option of dedicated Canonical support engineers. Ubuntu Advantage tiers are based on the size of your deployment and the support levels you need.</p>
-    <p class="twelve-col"><a href="https://buy.ubuntu.com" class="button--primary"><span class="external">Visit the Ubuntu Advantage store</span></a></p>
-    <p class="twelve-col">
-      <a href="/management/contact-us">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a>
-    </p>
+    <p><a href="https://buy.ubuntu.com" class="button--primary"><span class="external">Visit the Ubuntu Advantage store</span></a></p>
+    <p><a href="/management/contact-us">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
   </div><!-- /.eight-col -->
   <div class="four-col last-col">
     <img src="{{ ASSET_SERVER_URL }}544a9eb7-image-ubuntuadvantage.svg" alt="" width="378" height="180" class="priority-0" />
@@ -209,7 +207,7 @@
         </tr>
       </tbody>
     </table>
-    <p class="prepend-six"><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-desktop" class="button--primary"><span class="external">Buy Ubuntu Advantage desktop</span></a></p>
+    <p><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-desktop" class="button--primary"><span class="external">Buy Ubuntu Advantage desktop</span></a></p>
   </div>
 </div><!-- .row -->
 

--- a/templates/management/ubuntu-advantage.html
+++ b/templates/management/ubuntu-advantage.html
@@ -15,7 +15,7 @@
   <h1>Ubuntu Advantage</h1>
   <div class="eight-col">
     <p>Ubuntu Advantage is the professional package of tooling, technology and expertise from Canonical, helping organisations around the world to manage their Ubuntu deployments. It includes access to Landscape, the systems management tool for using Ubuntu at scale, as well as 24x7 telephone and web support and the option of dedicated Canonical support engineers. Ubuntu Advantage tiers are based on the size of your deployment and the support levels you need.</p>
-
+    <p class="twelve-col"><a href="https://buy.ubuntu.com" class="button--primary"><span class="external">Visit the Ubuntu Advantage store</span></a></p>
     <p class="twelve-col">
       <a href="/management/contact-us">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a>
     </p>
@@ -209,6 +209,7 @@
         </tr>
       </tbody>
     </table>
+    <p class="prepend-six"><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-desktop" class="button--primary"><span class="external">Buy Ubuntu Advantage desktop</span></a></p>
   </div>
 </div><!-- .row -->
 

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -144,6 +144,7 @@
         <h2 id="smarter-systems-management">Landscape &mdash; support and systems management</h2>
         <p>The Ubuntu Advantage service programme provides fast problem resolution, direct access to Ubuntu experts and efficient administration with the Ubuntu systems management package, Landscape.</p>
         <p>Landscape enables you to automate updates and control physical, virtual and cloud servers from a single interface. It&rsquo;s easy to set up and easy to use, giving you the power to manage thousands of machines as easily as you can manage one.</p>
+        <p><a href="https://buy.ubuntu.com" class="button--primary"><span class="external">Visit the Ubuntu Advantage store</span></a></p>
         <p><a href="/server/management">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     </div>
     <div class="four-col last-col equal-height__item equal-height__align-vertically">

--- a/templates/server/management.html
+++ b/templates/server/management.html
@@ -23,7 +23,8 @@
 			<div class="six-col no-margin-bottom last-col">
 				<p>Landscape is the systems management tool available with Ubuntu Advantage. It allows you to manage thousands of Ubuntu machines as easily as one, making the administration of Ubuntu desktops, servers and cloud instances more cost-effective.</p>
 			</div>
-			<p><a href="/management">Find out more about Landscape&nbsp;&rsaquo;</a></p>
+            <p><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers" class="button--primary"><span class="external">Buy Ubuntu Advantage for servers</span></a></p>
+            <p><a href="/management">Find out more about Landscape&nbsp;&rsaquo;</a></p>
 		</div><!-- /.twelve-col -->
 </div><!-- /.row -->
 

--- a/templates/shared/_ubuntu_advantage_server.html
+++ b/templates/shared/_ubuntu_advantage_server.html
@@ -88,7 +88,7 @@
     </tr>
   </tbody>
 </table>
-<p class="prepend-seven"><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers" class="button--primary"><span class="external">Buy Ubuntu Advantage for servers</span></a></p>
+<p class="twelve-col"><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers" class="button--primary"><span class="external">Buy Ubuntu Advantage for servers</span></a></p>
 <div class="seven-col" id="ua-virtual-guests">
   <h3>Ubuntu Advantage for virtual guests</h3>
   <p>Ubuntu Advantage for virtual guests has the same features as Ubuntu Advantage for server however:</p>

--- a/templates/shared/_ubuntu_advantage_server.html
+++ b/templates/shared/_ubuntu_advantage_server.html
@@ -88,6 +88,7 @@
     </tr>
   </tbody>
 </table>
+<p class="prepend-seven"><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers" class="button--primary"><span class="external">Buy Ubuntu Advantage for servers</span></a></p>
 <div class="seven-col" id="ua-virtual-guests">
   <h3>Ubuntu Advantage for virtual guests</h3>
   <p>Ubuntu Advantage for virtual guests has the same features as Ubuntu Advantage for server however:</p>

--- a/templates/shared/_ubuntu_advantage_whats_included.html
+++ b/templates/shared/_ubuntu_advantage_whats_included.html
@@ -39,6 +39,7 @@
             <p><a href="https://landscape.canonical.com/">Landscape login&nbsp;&rsaquo;</a></p>
         </div><!-- /.four-col -->
     </div><!-- /.twelve-col -->
+    <p><a href="https://buy.ubuntu.com" class="button--primary"><span class="external">Buy Ubuntu Advantage</span></a></p>
     {% if level_2 != 'ubuntu-advantage' %}{# Don't show this if on /management/ubuntu-advantage #}
         <p><a href="/management/ubuntu-advantage">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
     {% endif %}

--- a/templates/shared/contextual_footers/_download_enterprise_support.html
+++ b/templates/shared/contextual_footers/_download_enterprise_support.html
@@ -1,3 +1,4 @@
-<h3 class="contextual-footer__title">Enterprise support</h3>
-<p class="contextual-footer__text">Learn more about Ubuntu Advantage with Landscape.</p>
-<p class="contextual-footer__text"><a href="/management/ubuntu-advantage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Ubuntu Advantage page', 'eventLabel' : 'Enterprise support', 'eventValue' : undefined });">Ubuntu Advantage&nbsp;›</a></p>
+<h3 class="contextual-footer__title">Professional support for Ubuntu</h3>
+<p class="contextual-footer__text">Get professional support for Ubuntu from Canonical. We help organisations around the world to manage their Ubuntu cloud, server and desktop deployments.</p>
+<p class="contextual-footer__text"><a href="https://buy.ubuntu.com" class="button--primary"><span class="external">Buy Ubuntu Advantage</span></a></p>
+<p class="contextual-footer__text"><a href="/management/ubuntu-advantage" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Ubuntu Advantage page', 'eventLabel' : 'Enterprise support', 'eventValue' : undefined });">Find out more&nbsp;›</a></p>

--- a/templates/shared/contextual_footers/_server_contact_us.html
+++ b/templates/shared/contextual_footers/_server_contact_us.html
@@ -1,3 +1,4 @@
-<h3 class="contextual-footer__title">Ubuntu for business</h3>
-<p class="contextual-footer__text">Contact us about Ubuntu {% if level_2 == 'management' %}Advantage{% else %}Server{% endif %}.</p>
+<h3 class="contextual-footer__title">Ubuntu Advantage for business</h3>
+<p class="contextual-footer__text">Get professional support {% if level_2 == 'management' %}with Ubuntu Advantage{% else %}for Ubuntu Server{% endif %} from Canonical.</p>
+<p class="contextual-footer__text"><a href="https://buy.ubuntu.com" class="button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'Ubuntu Advantage store', 'eventValue' : undefined });"><span class="external">Visit the store</span></a></p>
 <p class="contextual-footer__text"><a href="/server/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server contact-us', 'eventLabel' : 'For business', 'eventValue' : undefined });">Get in touch&nbsp;&rsaquo;</a></p>

--- a/templates/shared/contextual_footers/_server_download.html
+++ b/templates/shared/contextual_footers/_server_download.html
@@ -1,3 +1,3 @@
 <h3 class="contextual-footer__title">Download</h3>
 <p class="contextual-footer__text">Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
-<p class="contextual-footer__text"><a href="/download/server" class="button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server download', 'eventLabel' : 'Download', 'eventValue' : undefined });">Download now</a></p>
+<p class="contextual-footer__text"><a href="/download/server" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'server download', 'eventLabel' : 'Download', 'eventValue' : undefined });">Get Ubuntu Server&nbsp;&rsaquo;</a></p>


### PR DESCRIPTION
## Done

* added many buttons and links to buy.ubuntu.com
* I didn't follow the doc religiously, it was too much and updated the text a bit to make more sense

## QA

[demo site](http://www.ubuntu.com-links_to_buy-u-c.demo.haus/)

1. Change request: Add CTA link above “Contact us about Ubuntu Advantage” which says “Visit Ubuntu Advantage store” and links to https://buy.ubuntu.com/

* check - /management  [copy doc](https://docs.google.com/document/d/1zT7brp0Jqr5CLnp1CIODOZ6ruohoGbTRB0giEyiRmSo/edit)

2. Change request: Add CTA link under “Learn more about Ubuntu Advantage” which says “Buy Ubuntu Advantage” and links to https://buy.ubuntu.com/ 

* check - _ubuntu_advantage_whats_included - added buy button
	* /management
	* /management/ubuntu-advantage
	* /server/hyperscale
	* /server/management

3. Change request: Replace CTA link with “Visit Ubuntu Advantage store” and links to https://buy.ubuntu.com/


4. Change request: Add CTA link under “Learn more” which says “Buy Ubuntu Advantage” and links to https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers

* check - /management/ubuntu-advantage [copy doc](https://docs.google.com/document/d/1PmWJqPvOvNjUmLs_6UYtLhWySNzdxQxg6NimoD1eiOw/edit)

5. Change request: Add CTA link underneath “Learn more about Ubuntu Advantage” which says “Visit Ubuntu Advantage store” which links to https://buy.ubuntu.com/

* check -  /server [copy doc](https://docs.google.com/document/d/1GqYEDkZPsCaLY9zXr9iX7nyIX9DBpE8i5A5Lx0rsUJg/edit#heading=h.axvf52ehx373) 

6. Change request: In the “Ubuntu for business” section, add “Professional support for Ubuntu Server available from Canonical” with CTA link underneath “Visit Ubuntu Advantage store” which links to https://buy.ubuntu.com/

* check - _server_contact_us 

7. Change request: Add CTA link under “Find out more about Landscape” which says “Buy Ubuntu Advantage for Servers” and links to https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers

* check -  /server/management [copy doc](https://docs.google.com/document/d/1Oqzs4utcIAdmFwZlSqlA6m5ioDlNnAjj_OTi_RHF2f8/edit)

8. Change request: Add a link underneath CTA button which says “Buy Ubuntu Advantage” which links to https://buy.ubuntu.com/

* check - /desktop/enterprise [copy doc](https://docs.google.com/document/d/1OcjFhwRofOdcWdJsNHZMvRowqhHNN0R2-aqJfK22ho8/edit)

9. Change request: Replace “Enterprise Support” section with 

Professional support for Ubuntu
Get professional support for Ubuntu from Canonical. We help organisations around the world to manage their Ubuntu cloud, server and desktop deployments.

Find out more (which links to http://www.ubuntu.com/management/ubuntu-advantage )
Buy Ubuntu Advantage (which links to https://buy.ubuntu.com/)

* check - /download and /download/server/arm

## Issue / Card

* [trello card](https://trello.com/c/bfR13Xa6)
* [brief](https://docs.google.com/document/d/1dVCnWvKkEN-84WyGOMGvmGrMToHdqLBv5_8i-lbfEfo/edit)
* [details](https://docs.google.com/document/d/1SHFbVbgG340KpP3L45PtZ9P0Qx1ek9wZ1q7_t0wgpM0/edit#)

