### PR TITLE
remove 8 student minimum

### DIFF
--- a/templates/cloud/training/index.html
+++ b/templates/cloud/training/index.html
@@ -81,7 +81,7 @@
             <div class="equal-height--vertical-divider twelve-col">
                 <div class="equal-height--vertical-divider__item seven-col">
                     <h3>Onsite training</h3>
-                    <p>3-day hands-on course at your premises for up to 15 students, with a minimum of 8 students required, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
+                    <p>3-day hands-on course at your premises for up to 15 students, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
                     <p><a class="external" href="https://assets.ubuntu.com/v1/1f2e7629-Ubuntu_Server_Administration_Training_06.07.16-2-2.pdf">Read the course outline (PDF)</a></p>
                 </div>
                 <div class="equal-height--vertical-divider__item five-col last-col" itemscope itemtype="http://data-vocabulary.org/Event">


### PR DESCRIPTION
## Done

* removed 8 student minimum from /cloud/training

## QA

1. go to /cloud/training
2. see that the 8 person minimum was removed from Ubuntu Server Administration and matches the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit)

## Issue / Card

[trello card](https://trello.com/c/UNiYqq0m)