### PR TITLE
update of the section_title for /desktop/snappy

### DIFF
--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -6,7 +6,7 @@
 {% block meta_keywords %}snappy, Ubuntu Core, Ubuntu 16.04 LTS, snaps, apps, debs, snap, docker, coreos, atomic, snapcraft, snapd{% endblock meta_keywords %}
 
 {% block second_level_nav_items %}
-	{% include "templates/_nav_breadcrumb.html" with section_title="Cloud" page_title="Ubuntu Core on the Cloud" %}
+	{% include "templates/_nav_breadcrumb.html" with section_title="Desktop" page_title="Ubuntu Core on the Cloud" %}
 {% endblock second_level_nav_items %}
 
 {% block content %}


### PR DESCRIPTION
## Done

* when you are on http://www.ubuntu.com/desktop/snappy, the main navigation chain started with Cloud instead of desktop, so need to change the Cloud to Desktop on the nav bar for this page


## QA

1. go to /desktop/snappy and see it now is part of the Desktop section

## Issue / Card

Fixes #807 