### PR TITLE
update to UK title case for partner programmes

### DIFF
--- a/templates/cloud/partners/index.html
+++ b/templates/cloud/partners/index.html
@@ -93,9 +93,9 @@
         <img src="{{ ASSET_SERVER_URL }}f7bff337-logo-juju-171x174.png" width="171" height="171" alt="Juju" />
     </div>
     <div class="eight-col last-col equal-height__item">
-        <h2>Charm Partner Programme</h2>
-        <p>Canonical&rsquo;s Charm Partner Programme helps you leverage the power of Juju, the ground-breaking service modelling tool, by helping you create Juju charms for your products. Charms encapsulate all the important configuration information, defining how your services will be deployed and how they will work with other services.</p>
-        <p><a href="http://partners.ubuntu.com/partner-programmes/software#charm-partner-programme">Learn more about the Charm Partner Programme&nbsp;&rsaquo;</a></p>
+        <h2>Charm partner programme</h2>
+        <p>Canonical&rsquo;s Charm partner programme helps you leverage the power of Juju, the ground-breaking service modelling tool, by helping you create Juju charms for your products. Charms encapsulate all the important configuration information, defining how your services will be deployed and how they will work with other services.</p>
+        <p><a href="http://partners.ubuntu.com/partner-programmes/software#charm-partner-programme">Learn more about the Charm partner programme&nbsp;&rsaquo;</a></p>
     </div>
     <div class="four-col for-small align-center">
         <img src="{{ ASSET_SERVER_URL }}f7bff337-logo-juju-171x174.png" width="171" height="171" alt="Juju" />
@@ -104,9 +104,9 @@
 
 <div class="row">
     <div class="eight-col">
-        <h2>Ubuntu OpenStack Interoperability Lab</h2>
-        <p>Ubuntu is the world&rsquo;s most popular choice for OpenStack clouds. And as more new solutions are developed for OpenStack, interoperability between components becomes increasingly important. With the Ubuntu OpenStack Interoperability Lab, we test and integrate your hardware and software rigorously, to ensure all components can be combined reliably in real-world deployments. </p>
-        <p><a href="http://partners.ubuntu.com/partner-programmes/openstack">Learn more about the Ubuntu Openstack Interoperability Lab&nbsp;&rsaquo;</a></p>
+        <h2>Ubuntu OpenStack interoperability lab</h2>
+        <p>Ubuntu is the world&rsquo;s most popular choice for OpenStack clouds. And as more new solutions are developed for OpenStack, interoperability between components becomes increasingly important. With the Ubuntu OpenStack interoperability lab, we test and integrate your hardware and software rigorously, to ensure all components can be combined reliably in real-world deployments. </p>
+        <p><a href="http://partners.ubuntu.com/partner-programmes/openstack">Learn more about the Ubuntu Openstack interoperability lab&nbsp;&rsaquo;</a></p>
     </div><!-- /.eight-col -->
     <a href="https://insights.ubuntu.com/2013/08/29/ubuntu-openstack-factsheet/" class="four-col box box-highlight resource--link resource-factsheet last-col">
         <h2>Ubuntu OpenStack factsheet&nbsp;&rsaquo;</h2>
@@ -121,8 +121,8 @@
     </div>
     <div class="eight-col last-col">
         <h2>World leading public cloud partners</h2>
-        <p>If you operate a public cloud or you&rsquo;re considering launching one, the Ubuntu Certified Public Cloud programme lets you make certified, secure and up to date Ubuntu images available to your users, along with the opportunity to sell management, monitoring and commercial support from Canonical &mdash; all of which represent additional revenue opportunities.</p>
-        <p><a href="http://partners.ubuntu.com/partner-programmes/public-cloud">Learn more about the Ubuntu Certified Public Cloud programme&nbsp;&rsaquo;</a></p>
+        <p>If you operate a public cloud or you&rsquo;re considering launching one, the Ubuntu certified public cloud programme lets you make certified, secure and up to date Ubuntu images available to your users, along with the opportunity to sell management, monitoring and commercial support from Canonical &mdash; all of which represent additional revenue opportunities.</p>
+        <p><a href="http://partners.ubuntu.com/partner-programmes/public-cloud">Learn more about the Ubuntu certified public cloud programme&nbsp;&rsaquo;</a></p>
     </div><!-- /.eight-col -->
 </div><!-- /.row row-hero -->
 
@@ -144,7 +144,7 @@
     </div>
     <div class="eight-col last-col">
         <h2>Become a cloud partner</h2>
-        <p>To learn more about becoming a Charm, Ubuntu Certified Public Cloud or Ubuntu OpenStack partner, please contact us today.</p>
+        <p>To learn more about becoming a Charm, Ubuntu certified public cloud or Ubuntu OpenStack partner, please contact us today.</p>
         <p><a href="http://partners.ubuntu.com/contact-us" class="button--primary">Get in touch</a> or <a href="http://partners.ubuntu.com/partnering-with-us" class="external">Learn more about partnering with us</a></p>
     </div>
 </div>

--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -347,7 +347,7 @@
         <h3 id="ua-virtual-guest">Ubuntu Advantage Virtual Guest</h3>
 
         <ul>
-            <li>Services are provided for Ubuntu Server when installed and running in a virtualized environment on a physical host or in an Ubuntu Certified Public Cloud partner&#39;s environment. Certified Public Cloud partners can be found in the Ubuntu partner listing: <a href="http://partners.ubuntu.com/find-a-partner">partners.ubuntu.com/find-a-partner</a></li>
+            <li>Services are provided for Ubuntu Server when installed and running in a virtualized environment on a physical host or in an Ubuntu certified public cloud partner&#39;s environment. Certified Public Cloud partners can be found in the Ubuntu partner listing: <a href="http://partners.ubuntu.com/find-a-partner">partners.ubuntu.com/find-a-partner</a></li>
             <li>Service exclusions match those of the applicable Ubuntu Advantage Server service offering.</li>
         </ul>
 

--- a/templates/shared/_ubuntu_advantage_server.html
+++ b/templates/shared/_ubuntu_advantage_server.html
@@ -94,7 +94,7 @@
   <p>Ubuntu Advantage for virtual guests has the same features as Ubuntu Advantage for server however:</p>
   <ul class="list-ticks--canonical">
     <li>It must be bought in 10-pack units</li>
-    <li>It is only available for guests in Ubuntu Certified Public Clouds and OpenStack environments</li>
+    <li>It is only available for guests in Ubuntu certified public clouds and OpenStack environments</li>
     <li>It is only available at Standard and Advanced levels</li>
   </ul>
 </div>

--- a/templates/takeovers/_uoil_takeover.html
+++ b/templates/takeovers/_uoil_takeover.html
@@ -2,7 +2,7 @@
 	<div class="hero clearfix">
 		<div>
 			<h1>All working together</h1>
-			<p class="tagline">Announcing the Ubuntu OpenStack Interoperability Lab: integration and testing for cloud software and hardware.</p>
+			<p class="tagline">Announcing the Ubuntu OpenStack interoperability lab: integration and testing for cloud software and hardware.</p>
 			<p><a href="/cloud/ecosystem/ubuntu-openstack-interoperability-lab">Learn more about the lab&nbsp;&rsaquo;</a></p>
 		</div>
 	</div>


### PR DESCRIPTION
## Done

* updated to UK title (US sentence) case for partner programme names
 * OpenStack Interoperability Lab should be OpenStack interoperability lab
 * Charm Partner Programme should be Charm partner programme
 * Ubuntu Channel Partner Programme should be Ubuntu channel partner programme
 * Ubuntu Certified Public Cloud programme should be Ubuntu certified public cloud programme

## QA

1. go to /cloud/partners to see most of the changes - compare to the [copy doc](https://docs.google.com/document/d/1J2AxzOkFgkXyV7C7VO7ZJ0urzbEtrqRYCRt1SL64f3I/edit#)
2. go to /legal/ubuntu-advantage/service-description to see one change - compare to the [copy doc](https://docs.google.com/document/d/1mrNrsC1WDf6QTg3nrVCEZS8vJzGz1fokvoFDVC4s_mI/edit)
3. go to /server/management and see the Ubuntu certified public cloud is sentence case in the 'Ubuntu Advantage for virtual guests ' section [copy doc] (https://docs.google.com/document/d/1Oqzs4utcIAdmFwZlSqlA6m5ioDlNnAjj_OTi_RHF2f8/edit)
4. go to /management/ubuntu-advantage and see the Ubuntu certified public cloud is sentence case in the 'Ubuntu Advantage for virtual guests ' section [copy doc](https://docs.google.com/document/d/1PmWJqPvOvNjUmLs_6UYtLhWySNzdxQxg6NimoD1eiOw/edit#heading=h.e6cymmruaj73)

## Issue / Card

Fixes #814 
