### PR TITLE
reverted to old takeover

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base_index.html" %}
 
 
-{% block takeover_body_class %}homepage-linux-25th-takeover{% endblock takeover_body_class %}
+{% block takeover_body_class %}homepage-autopilot-devops-takeover{% endblock takeover_body_class %}
 
 {% block head_extra %}
 
@@ -10,7 +10,7 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_linux-25th.html" %}
+{% include "takeovers/_autopilot-devops.html" %}
 
 <section class="row row--ubuntu-news js-hidden row-grey strip no-border">
     <div class="strip-inner-wrapper">


### PR DESCRIPTION
## Done

Reverted the homepage takeover to the previous one.

## QA

See that the takeover is now the old devops one not the birthday one.