### PR TITLE
Remove Ubuntu Server Administration row from cloud/training

### DIFF
--- a/templates/cloud/training/index.html
+++ b/templates/cloud/training/index.html
@@ -74,33 +74,6 @@
         </li>
     </ul>
 </div>
-<div class="row">
-    <ul class="list twelve-col no-bullets">
-        <li>
-            <h2>Ubuntu Server Administration</h2>
-            <div class="equal-height--vertical-divider twelve-col">
-                <div class="equal-height--vertical-divider__item seven-col">
-                    <h3>Onsite training</h3>
-                    <p>3-day hands-on course at your premises for up to 15 students, that will provide fundamental instruction on how to install and administer Ubuntu Server.</p>
-                    <p><a class="external" href="https://assets.ubuntu.com/v1/1f2e7629-Ubuntu_Server_Administration_Training_06.07.16-2-2.pdf">Read the course outline (PDF)</a></p>
-                </div>
-                <div class="equal-height--vertical-divider__item five-col last-col" itemscope itemtype="http://data-vocabulary.org/Event">
-                    <dl class="course-details">
-                        <dt>Duration</dt>
-                        <dd itemprop="duration">3 days</dd>
-                        <dt>Cost</dt>
-                        <dd>USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="14500.00">14,500</span> up to 15 attendees</dd>
-                        <dt>Location</dt>
-                        <dd>Your premises</dd>
-                        <dt>Availability</dt>
-                        <dd>from 10 October 2016</dd>
-                    </dl>
-                    <p><a href="/cloud/training/server-admin-onsite-contact-us">Contact us to book yours&nbsp;&rsaquo;</a></p>
-                </div>
-            </div>
-        </li>
-    </ul>
-</div>
 
 <div class="row no-border">
   <div class="seven-col">


### PR DESCRIPTION
## Done

Remove Ubuntu Server Administration row from cloud/training

## QA

Go to /cloud/training and make sure the Ubuntu Server Administration row has been removed
