### PR TITLE
update end of life chart for spelling mistake

### DIFF
--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -2,7 +2,11 @@
     <div class="seven-col equal-height__item equal-height__align-vertically">
         <div>
             <h3>Ubuntu release cycle</h3>
-            <img src="{{ ASSET_SERVER_URL }}1d30651f-release-chart-desktop_small.png?w=540" srcset="{{ ASSET_SERVER_URL }}1d30651f-release-chart-desktop_small.png?w=431 880w, {{ ASSET_SERVER_URL }}1d30651f-release-chart-desktop_small.png?w=305 980w, {{ ASSET_SERVER_URL }}1d30651f-release-chart-desktop_small.png?w=540 1064w" alt="Ubuntu Desktop release cycle, 5 year long-term support" />
+            <img src="{{ ASSET_SERVER_URL }}a5f068c2-desktop-release-eol.png?w=540"
+                srcset="{{ ASSET_SERVER_URL }}a5f068c2-desktop-release-eol.png?w=431 880w,
+                {{ ASSET_SERVER_URL }}a5f068c2-desktop-release-eol.png?w=305 980w,
+                {{ ASSET_SERVER_URL }}a5f068c2-desktop-release-eol.png?w=540 1064w"
+                alt="Ubuntu Desktop release cycle, 5 year long-term support" />
         </div>
     </div>
     <div class="five-col last-col equal-height__item equal-height__align-vertically">


### PR DESCRIPTION
## Done

* fixed a typo on the desktop release end of life chart

## QA

1. go to /server and see the chart's key is spelled correctly 'Maintenance'

## Issue / Card

Fixes #825 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/18342313/21705cf4-75a6-11e6-8b29-ac90608f3318.png)


