### PR TITLE
Unbreak breadcrumbs

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -171,6 +171,13 @@ body {
   }
 }
 
+// Hide the breadcrumb expand button in expanded nav
+@media only screen and (min-width: $navigation-threshold) {
+  .nav-secondary .breadcrumb li .after {
+    display: none;
+  }
+}
+
 .breadcrumb .third-level-nav .active a {
   color: $ubuntu-orange;
 }


### PR DESCRIPTION
The `.after` element being added by JS was breaking the layout of the breadcrumbs menu on the expanded version of the menu on wider screens.

This PR hides that element in those displays.

Fixes #834.

QA
--

```
make run
```

Visit e.g. <http://127.0.0.1:8001/cloud/openstack>.

Check breadcrumbs looks okay on wider screens, and the expand/collapse functionality still looks okay and works on smaller screens.
