### PR TITLE
remove breadcrumb padding on large screen

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -179,6 +179,13 @@ body {
   color: $warm-grey;
 }
 
+@media only screen and (min-width: $navigation-threshold) {
+  .nav-secondary .breadcrumb li a.after {
+    display: none;
+  }
+}
+
+
 @media only screen and (max-width: $navigation-threshold - 1) {
   .breadcrumbs .second-level-nav,
   .breadcrumbs .second-level-nav:hover,


### PR DESCRIPTION
## Done

* remove the <a class="after" styling that is added for the mobile nav chevron

## QA

1. go to /phone and /cloud
2. see that the nav looks ok in large and small screens

## Issue / Card

Fixes #834

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/18385007/d09d0242-7685-11e6-9aa1-ff13d66d379d.png)


