### PR TITLE
update download/cloud ebook row

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -282,6 +282,11 @@ html.opera-mini {
     margin-bottom: 0;
 }
 
+.download-cloud-home .row--ebook {
+  background: $dark-aubergine;
+  color: #ebebea;
+}
+
 .download-desktop {
   div.warning {
     padding: 20px 40px;

--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -221,14 +221,16 @@ html.opera-mini {
 
 .download {
   .inner-wrapper {
+
     form fieldset {
       background: none;
       margin: 0;
-      padding-left: $gutter-width;
-      padding-top: 2px;
       padding-bottom: 0;
+      padding-left: 0;
       padding-right: 0;
+      padding-top: 2px;
     }
+
     form select {
       font-weight: 300;
       margin-bottom: 30px;

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -13,7 +13,7 @@
 
 {% block content %}
 
-<div class="row row-grey">
+<div class="row row-grey no-border">
     <div class="strip-inner-wrapper">
         <h1>Get OpenStack Autopilot</h1>
         <p class="intro">Canonical&rsquo;s <a href="/cloud/openstack/autopilot">OpenStack Autopilot</a> fully automates the deployment of an OpenStack Cloud &mdash; just add servers.</p>

--- a/templates/download/shared/_get_ebook.html
+++ b/templates/download/shared/_get_ebook.html
@@ -1,8 +1,8 @@
-<div class="row row--dark no-border">
+<div class="row row--ebook no-border">
     <div class="strip-inner-wrapper">
         <h2>Before you start, you&rsquo;ll want this eBook</h2>
         <div class="six-col append-one">
-            <p class="not-for-small"><img src="{{ ASSET_SERVER_URL }}8374158b-openstack-made-easy-illustration.png" alt="" class="not-for-small six-col"></p>
+            <p class="not-for-small"><img src="{{ ASSET_SERVER_URL }}8697cae9-openstack-made-easy-illustration.svg" height="335" alt="" class="not-for-small"></p>
             <p>The phase change from traditional, monolithic software to multi-host microservices-based big software demands that you approach the challenge of deployment, integration and operations from a different perspective.</p>
             <p>This eBook will give you a deeper understanding into why there is a perceived complexity to the installation and operations of OpenStack and how tools like Canonical&rsquo;s OpenStack Autopilot can help you build a modern, scalable, repeatable and affordable private cloud infrastructure.</p>
         </div>


### PR DESCRIPTION
## Done

updated the look of the ebook row on download/cloud per @yaili 

## QA

1. go to /download/cloud
2. see that the hero row as no border
3. see that the ebook row is aubergine and has a new image

## Issue / Card

Fixes #838 Update design of ebook strip in /download/cloud 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/18389451/e9cab936-769d-11e6-8ddb-b7da4fbf1d6e.png)
