### PR TITLE
use full size image on desktop/features

### DIFF
--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -257,7 +257,7 @@
             <p>By enabling online search, smart filters make it faster and easier to find the content you need, whether it’s stored on your computer or on the web. Type any query into the Dash home and the Smart Scopes server will determine which categories of content are the most relevant to your search, returning only the best results. And it learns from your past searches making it increasingly accurate over time.</p>
         </div>
     </div>
-    <img src="{{ ASSET_SERVER_URL }}6c3738b9-smarter-searching.jpg" class="touch-border" alt="Unity search" width="984" />
+    <img src="{{ ASSET_SERVER_URL }}bcb09a5b-desktop-features-smarter-searching.jpg?op=region&amp;rect=140,0,910,300" class="touch-border" alt="Unity search" width="910" />
 </div>
 
 {% include "shared/_open_source_phone.html" %}


### PR DESCRIPTION
## Done

* uploaded full size version of smarter searching image to the asset server
* replaced on desktop/features with get string cropping

## QA

1. go to /desktop/features
2. see that the smarter searching image is nearly identical

## Issue / Card

Fixes #569

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/18391573/4ada3e24-76a6-11e6-9bb2-7c47f28173b6.png)

