### PR TITLE
Fix broken tablet links

### DIFF
--- a/templates/tablet/shared/_buy.html
+++ b/templates/tablet/shared/_buy.html
@@ -11,7 +11,7 @@
           <li>Full HD video camera</li>
           <li>2GB RAM</li>
         </ul>
-          <p><a itemprop="url" class="button--primary" href="https://store.bq.com/gl/ubuntu-edition/?utm_source=Ubuntu.com_{% if level_2 == 'features' %}features{% endif %}{% if level_1 == 'tablet' and not level_2 %}overview{% endif %}&amp;utm_medium=Button&amp;utm_campaign=m10-ubuntu-edition-canonical&amp;">Buy now</a></p>
+          <p><a itemprop="url" class="button--primary" href="https://store.bq.com/en/ubuntu-edition-aquaris-m10?utm_source=Ubuntu.com_{% if level_2 == 'features' %}features{% endif %}{% if level_1 == 'tablet' and not level_2 %}overview{% endif %}&amp;utm_medium=Button&amp;utm_campaign=m10-ubuntu-edition-canonical&amp;">Buy now</a></p>
           <p><a href="/tablet/devices">Learn more about the BQ M10&nbsp;&rsaquo;</a></p>
       </div>
     </div>


### PR DESCRIPTION
Fixes #843.

QA
--

```
make run
```

Visit <http://127.0.0.1:8001/tablet> and <http://127.0.0.1:8001/tablet/features>. Click "Buy" button on both pages - check it takes you to a real page where you can buy a fabulous Ubuntu tablet.