### PR TITLE
update burn dvd on mac instructions

### DIFF
--- a/templates/download/desktop/burn-a-dvd-on-mac-osx.html
+++ b/templates/download/desktop/burn-a-dvd-on-mac-osx.html
@@ -17,7 +17,7 @@
         <div class="nine-col append-one">
             <h1>How to burn a DVD on OS X</h1>
             <p>Before you begin, you need to <a href="/download">download Ubuntu</a> and, if you want, <a href="/download/how-to-verify">verify the download</a>.</p>
-            <p>The easiest way to burn an ISO, the file you need to install Ubuntu from a DVD, is by using <strong>Disk Utility</strong>. If you&rsquo;re using an older version of Mac OS X, you might not have the Disk Utility application. In this case, use Disk Copy.</p>
+            <p>The easiest way to burn an ISO, the file you need to install Ubuntu from a DVD, is by right clicking on the file in the <strong>Finder</strong>.  If you are using an older version of Mac OS X, you might need to use the Disk Utility, or on even older versions of Mac OS X, you might need to use use Disk Copy.</p>
         </div>
     </div>
 </div>
@@ -25,28 +25,28 @@
     <div class="strip-inner-wrapper">
         <ol class="list-stepped eight-col append-one">
             <li class="list-stepped__item">
-                <p>Launch <strong>'Disk Utility'</strong> (Applications &rarr; Utilities &rarr; Disk Utility).</p>
+                <p>Right click on the Ubuntu .iso file</p>
             </li>
             <li class="list-stepped__item">
-                <p>Insert your blank DVD.</p>
-            </li>
-            <li class="list-stepped__item">
-                <p>Drag and drop your .iso file to the left pane in Disk Utility. Now both the blank disc and the .iso should be listed.</p>
-            </li>
-            <li class="list-stepped__item">
-                <p>Select the .iso file, and click on the <strong>'Burn'</strong> button in the toolbar.</p>
+                <p>Select <strong>'Burn Disk Image'</strong> option</p>
                 <div class="help-image">
-                    <a href="{{ ASSET_SERVER_URL }}53029019-desktop-burn-a-dvd-on-mac-4.png" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}53029019-desktop-burn-a-dvd-on-mac-4.png?w=444" alt="" height="388" width="444"></a>
+                    <a href="{{ ASSET_SERVER_URL }}9bde8b42-burn-dvd-osx-step-2.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}9bde8b42-burn-dvd-osx-step-2.jpg?w=444" alt="" height="427" width="444"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p>Ensure that the <strong>'Verify burned data'</strong> checkbox is ticked (you may need to click on the disclosure triangle to see the checkbox).</p>
+                <p>Insert a blank DVD</p>
+            </li>
+            <li class="list-stepped__item">
+                <p>Click the <strong>'Burn'</strong> button on the dialog menu</p>
                 <div class="help-image">
-                    <a href="{{ ASSET_SERVER_URL }}65cc3384-desktop-burn-a-dvd-on-mac-5.png" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}65cc3384-desktop-burn-a-dvd-on-mac-5.png?w=444" alt="" height="388" width="444"></a>
+                    <a href="{{ ASSET_SERVER_URL }}364d2cef-burn-dvd-osx-step-3.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}364d2cef-burn-dvd-osx-step-3.jpg?w=444" alt="" height="299" width="444"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p>Click <strong>'Burn'</strong>. The data will be burned and verified.</p>
+                <p>The data will be burned and verified</p>
+                <div class="help-image">
+                    <a href="{{ ASSET_SERVER_URL }}5025bfef-burn-dvd-osx-step-4.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}5025bfef-burn-dvd-osx-step-4.jpg?w=444" alt="" height="272" width="444"></a>
+                </div>
             </li>
         </ol>
     </div><!-- /.box -->


### PR DESCRIPTION
## Done

* tested and rewrote the mac osx instructions for El Capitan and up
* updated the [copy doc](https://docs.google.com/document/d/1UH6y_7aLGjDnrNZcv8PO009e_qjf0ifQUWirMhKB5fQ/edit)
* updated all the screenshots

## QA

1. go to /download/desktop/burn-a-dvd-on-mac-osx
2. read the instructions see that they make sense

## Issue / Card

Fixes [1584376](https://bugs.launchpad.net/ubuntu-website-content/+bug/1584376)
