### PR TITLE
remove imager.js from site

### DIFF
--- a/templates/about/ubuntu-font.html
+++ b/templates/about/ubuntu-font.html
@@ -9,16 +9,8 @@
 
 <div class="row no-border">
 	<div class="twelve-col">
-		<div class="ubuntufont-image-load" data-width="900" data-src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/about/ubuntu-font{width}.jpg" data-alt=""></div>
-		<script>
-		    new Imager('.ubuntufont-image-load', {
-		        availableWidths: {
-		            320: '-small',
-		            900: '-medium'
-		        }
-		    });
-		</script>
-	</div>
+        <img src="{{ ASSET_SERVER_URL }}747d3f40-ubuntu-font.jpg" alt="Ubuntu font samples" />
+    </div>
 	<div class="six-col">
 		<p>Fonts have become one of the most essential communication tools today.</p><p>They allow us to convey our thoughts to one another, be that by letter or text message, with clarity and purpose.</p><p>Dalton Maag, a London-based studio, has laid the foundations for the Ubuntu font project with a beautiful design that aims to produce every character to support every language and interest in the world.</p><p>This is the most ambitious font project ever undertaken. Its success depends on the willingness of designers around the world to participate and work with the teams at Dalton Maag and Canonical to deliver the most comprehensive font suite ever. It&rsquo;s a true testament to the power of collaborative working in technology and design.</p>
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -57,13 +57,12 @@
 
 <!-- javascript -->
 <script src="{{ ASSET_SERVER_URL }}b0601acd-modernizr.2.7.1.js"></script>
-<script src="{{ ASSET_SERVER_URL }}2c8fd8c9-Imager.js"></script>
 
-{% comment %}<!-- the following has been added to allow things/iot ab testing -->{% endcomment %}
+{% comment %}<!-- the following has been added to allow things/iot ab testing -->
 <script src="https://www.google-analytics.com/cx/api.js?experiment=IbIACoOrTnG8eSnRY64nWQ"></script>
 <script>
   var chosenVariation = cxApi.chooseVariation();
-</script>
+</script> <!-- not currently testing... left for easy of readding-->{% endcomment %}
 
 {% block head_extra %}{% endblock %}
 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -58,12 +58,6 @@
 <!-- javascript -->
 <script src="{{ ASSET_SERVER_URL }}b0601acd-modernizr.2.7.1.js"></script>
 
-{% comment %}<!-- the following has been added to allow things/iot ab testing -->
-<script src="https://www.google-analytics.com/cx/api.js?experiment=IbIACoOrTnG8eSnRY64nWQ"></script>
-<script>
-  var chosenVariation = cxApi.chooseVariation();
-</script> <!-- not currently testing... left for easy of readding-->{% endcomment %}
-
 {% block head_extra %}{% endblock %}
 
 {% block crazy_egg %}{% endblock crazy_egg %}


### PR DESCRIPTION
## Done

* removed imager.js from base template
* removed single use of imager from /about/ubuntu-font
* driveby django commented out google a/b test code as currently there are no tests

## QA

[] go to /about/ubuntu-font and see the banner looks ok responsively (it was too small to use srcset)

## Issue / Card

Fixes #655 

