### PR TITLE
Remove YUI from global.js

### DIFF
--- a/static/js/global.js
+++ b/static/js/global.js
@@ -1,22 +1,24 @@
+var ai = [
+  { url: "http://www.ubuntu.com", title:"Ubuntu" },
+  { url: "http://community.ubuntu.com/", title:"Community" },
+  { url: "http://askubuntu.com", title:"Ask!" },
+  { url: "http://developer.ubuntu.com", title:"Developer" },
+  { url: "https://design.ubuntu.com", title:"Design" },
+  { url: "http://www.ubuntu.com/certification", title:"Hardware" },
+  { url: "https://insights.ubuntu.com", title:"Insights" },
+  { url: "https://jujucharms.com", title:"Juju" },
+  { url: "http://maas.ubuntu.com", title:"MAAS" },
+  { url: "http://partners.ubuntu.com", title:"Partners" },
+  { url: "https://buy.ubuntu.com/", title:"Shop" }
+];
 
-var ai = [{ url: "http://www.ubuntu.com", title:"Ubuntu" },
-{ url: "http://community.ubuntu.com/", title:"Community" },
-{ url: "http://askubuntu.com", title:"Ask!" },
-{ url: "http://developer.ubuntu.com", title:"Developer" },
-{ url: "https://design.ubuntu.com", title:"Design" },
-{ url: "http://www.ubuntu.com/certification", title:"Hardware" },
-{ url: "https://insights.ubuntu.com", title:"Insights" },
-{ url: "https://jujucharms.com", title:"Juju" },
-{ url: "http://maas.ubuntu.com", title:"MAAS" },
-{ url: "http://partners.ubuntu.com", title:"Partners" },
-{ url: "https://buy.ubuntu.com/", title:"Shop" }];
-
-var more = [{ url: "https://help.ubuntu.com", title:"Help" },
-{ url: "http://ubuntuforums.org", title:"Forum" },
-{ url: "http://www.launchpad.net", title:"Launchpad" },
-{ url: "http://shop.ubuntu.com", title:"Merchandise" },
-{ url: "http://www.canonical.com", title:"Canonical" }];
-
+var more = [
+  { url: "https://help.ubuntu.com", title:"Help" },
+  { url: "http://ubuntuforums.org", title:"Forum" },
+  { url: "http://www.launchpad.net", title:"Launchpad" },
+  { url: "http://shop.ubuntu.com", title:"Merchandise" },
+  { url: "http://www.canonical.com", title:"Canonical" }
+];
 
 if(!core){ var core = {}; }
 
@@ -28,48 +30,68 @@ core.setupGlobalNav = function () {
 core.getNav = function() {
   var begin = '<nav role="navigation" id="nav-global"><div class="nav-global-wrapper"><ul class="nav-global-main">';
   var end = '</ul></div></nav>';
-  var mu = '';
+  var navHtmlContents = '';
   var i = 0;
   while(i < ai.length) {
-    mu += '<li><a href="' + ai[i].url + '" ' + core.getActive(ai[i].url) + '>' + ai[i].title + '</a></li>';
+    navHtmlContents += '<li><a href="' + ai[i].url + '" ' + core.getActive(ai[i].url) + '>' + ai[i].title + '</a></li>';
     i++;
   }
   i = 0;
   if(more.length > 0) {
-    mu += '<li class="more"><a href="#">More <span>&rsaquo;</span></a><ul class="nav-global-more">';
-    while(i < more.length) { mu += '<li><a href="'+ more[i].url +'">' + more[i].title + '</a></li>'; i++; }
-    mu += '</ul>';
+    navHtmlContents += '<li class="more"><a href="#">More <span>&rsaquo;</span></a><ul class="nav-global-more">';
+    while(i < more.length) { navHtmlContents += '<li><a href="'+ more[i].url +'">' + more[i].title + '</a></li>'; i++; }
+    navHtmlContents += '</ul>';
   }
-  return begin + mu + end;
+  return begin + navHtmlContents + end;
 };
-core.deployNav = function(mu) {
-  var gI = 'body';
+
+core.deployNav = function(navHtmlContents) {
+  var containerSelector = 'body';
+  var ephemeralDiv = document.createElement('div');
+  ephemeralDiv.innerHTML = navHtmlContents;
+  var navContents = ephemeralDiv.childNodes[0];
+
   if(core.globalPrepend) {
-    gI = core.globalPrepend;
+    containerSelector = core.globalPrepend;
   }
-  YUI().use('node', function(Y) {
-    Y.one(gI).prepend(mu);
-    var ml = Y.one('#nav-global .more');
-    if(ml){
-      ml.on('click',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        this.toggleClass('open');
+
+  var navContainer = document.querySelector(containerSelector);
+  navContainer.insertBefore(navContents, navContainer.firstChild);
+
+  var moreLink = document.querySelector('#nav-global .more');
+
+  if(moreLink){
+    moreLink.addEventListener(
+      'click',
+      function(clickEvent){
+        clickEvent.stopPropagation();
+        clickEvent.preventDefault();
+        this.classList.toggle('open');
         return false;
-      });
-      ml.one('span').on('click',function(e){
-        e.preventDefault();
-        e.stopPropagation();
-      });
-      ml.one('ul').on('click',function(e){ e.stopPropagation(); });
-    }
-    Y.one('body').on('click', function(e){
-      var ml = Y.one('#nav-global .more');
-      if(ml.hasClass('open')){
-        ml.removeClass('open');
       }
-    });
-  });
+    );
+    moreLink.querySelector('span').addEventListener(
+      'click',
+      function(clickEvent){
+        clickEvent.preventDefault();
+        clickEvent.stopPropagation();
+      }
+    );
+    moreLink.querySelector('ul').addEventListener(
+      'click',
+      function(clickEvent){
+        clickEvent.stopPropagation();
+      }
+    );
+  }
+
+  document.body.addEventListener(
+    'click',
+    function(clickEvent) {
+      var moreLink = document.querySelector('#nav-global .more');
+      moreLink.classList.remove('open');
+    }
+  );
 };
 
 core.getActive = function(link) {
@@ -92,19 +114,34 @@ core.getURL = function(){
 };
 
 core.trackClicks = function() {
-  YUI().use('node', function(Y) {
-    Y.all('#nav-global a').on('click',function(e) {
-      e.preventDefault();
-      try {
-        _gaq.push(['_trackEvent', 'Global bar click', e.target.get('text'), core.getURL()]);
-      } catch(err){}
-      setTimeout(function() {
-        document.location.href = e.target.get('href');
-      }, 100);
-    });
-  });
+  document.querySelectorAll('#nav-global a').forEach(
+    function (linkElement) {
+      linkElement.addEventListener(
+        'click',
+        function(clickEvent) {
+          clickEvent.preventDefault();
+
+          try {
+            _gaq.push(['_trackEvent', 'Global bar click', clickEvent.target.innerText, core.getURL()]);
+          } catch(err){}
+
+          setTimeout(
+            function() {
+              document.location.href = clickEvent.target.href;
+            },
+            100
+          );
+        }
+      );
+    }
+  );
 };
 
-if(!core.globalPrepend) {
-  core.setupGlobalNav();
-}
+document.addEventListener(
+  'DOMContentLoaded',
+  function (loadEvent) {
+    if(!core.globalPrepend) {
+      core.setupGlobalNav();
+    }
+  }
+);

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -176,7 +176,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 <script src="{% versioned_static 'js/polyfills.js' %}"></script>
 <script src="{% versioned_static 'js/core.js' %}"></script>
-<script src="{{ ASSET_SERVER_URL }}94052790-global.js"></script>
+<script src="{{ ASSET_SERVER_URL }}ab9f5f4b-global.js"></script>
 <script src="{% versioned_static 'js/scratch.js' %}"></script>
 <script src="{{ ASSET_SERVER_URL }}f5bf3854-respond.min.js"></script>
 


### PR DESCRIPTION
But keep the same interface - global.js should still work everywhere, although it requires polyfills for the following to work cross-browser (arriving in #850):

- NodeList.forEach
- Element.addEventListener
- Element.classList

I also uploaded the new global.js to the assets server at: https://assets.ubuntu.com/v1/ab9f5f4b-global.js

QA
--

Check global nav behaves as expected - as it does on live.