### PR TITLE
Use new sliders for managed cloud aaaand..... REMOVE YUI!

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -896,52 +896,6 @@
   .option__value-savings.negative {
     color: $error;
   }
-
-  // Slider styles
-  .yui3-slider-content, .yui3-widget {
-    display: block;
-    padding: 5px 0;
-  }
-
-  .yui3-slider-rail-cap-left, .yui3-slider-rail-cap-right {
-    display: none;
-  }
-
-  .yui3-slider-rail {
-    display: block;
-    height: 4px;
-    background-color: $brand-color;
-    background: linear-gradient(to left, #E1DAD2 98.4%, $brand-color 0%); // DDD pick a standard colour?
-    border-radius: 2px;
-    overflow: visible;
-    box-shadow: inset 0px 1px 0px 0px rgba(0, 0, 0, 0.15);
-    cursor: pointer;
-
-    .yui3-slider-thumb {
-      width:  18px;
-      height: 18px;
-      border-radius: 4px;
-      background: $white;
-      overflow: visible;
-      display: block;
-      position: relative;
-      top: -7px !important;
-      outline: none;
-      box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .2);
-      cursor: pointer;
-
-      &:hover {
-        -webkit-transform: scale(1.25, 1.25);
-        transform: scale(1.25, 1.25);
-        -ms-transition: transform 0.1s cubic-bezier(0.895, 0.03, 0.685, 0.22);
-        transition:  transform 0.1s cubic-bezier(0.895, 0.03, 0.685, 0.22);
-      }
-    }
-  }
-
-  .yui3-slider-thumb-shadow, .yui3-slider-thumb-image {
-    display: none;
-  }
 }
 
 //* Special overrides for JS-enabled

--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -319,11 +319,6 @@
 
 //* Special overrides for JS-enabled  on /cloud/openstack/managed-cloud
 .js .cloud-openstack-managed-cloud {
-
-  .slider-area p {
-      float: none;
-  }
-
   .slider-container {
     min-height: 24px;
     min-width: 10px;
@@ -639,14 +634,15 @@
   .slider-area {
     margin-top: 20px;
     overflow: hidden;
+    display: flex;
 
-    p {
-      float: left;
-      margin-bottom: 0;
-
-      &:first-child {
-        margin-top: 0;
-      }
+    & input[type=number] {
+      width: 5em;
+      margin-right: 1em;
+    }
+    & input[type=range] {
+      min-width: 130px;
+      flex-grow: 1;
     }
   }
 
@@ -693,7 +689,18 @@
     list-style: none;
     margin-left: 0;
 
-    .grouped-tabbed__item {
+    &__input {
+      position: absolute;
+      left: -10000px;
+
+      &:checked ~ .grouped-tabbed__button {
+       background: $ubuntu-orange;
+       color: $white;
+       border-color: $ubuntu-orange;
+     }
+    }
+
+    &__item {
       float: left;
       margin-bottom: 0;
       width: 33%;
@@ -707,7 +714,7 @@
       }
     }
 
-    .grouped-tabbed__button {
+    &__button {
       text-align: center;
       padding: 8px;
       display: block;
@@ -716,17 +723,6 @@
       color: $ubuntu-orange;
       margin-left: -1px;
       margin-right: -1px;
-
-      &:hover,
-      &:focus {
-        text-decoration: none;
-      }
-
-      &.is-active {
-        background: $ubuntu-orange;
-        color: $white;
-        border-color: $ubuntu-orange;
-      }
     }
   }
 

--- a/static/js/cloud.js
+++ b/static/js/cloud.js
@@ -1,0 +1,150 @@
+if (typeof cloud !== "undefined") {
+    throw TypeError('Namespace "cloud" not available');
+}
+// Define this namespace
+var cloud = {};
+
+cloud.formatPrice = function(number) {
+  numberWithCommas = Math.ceil(number).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  amount = '$' + numberWithCommas;
+  amount = amount.replace('$-', '-$');
+  return amount;
+};
+
+cloud.calculator = function() {
+  var
+  /* Constants */
+  daysInYear = 365,
+  monthsInYear = 12,
+  daysInMonth = 30,
+  hoursInDay = 24,
+  hoursInMonth = hoursInDay * daysInMonth,
+  hoursInYear = hoursInDay * daysInYear,
+
+  /* Settings */
+  vmPerHour = 0.05,
+  uaPriceVm = 0.03,
+  bootstackServerDailyPrice = 15,
+  bootstackServerHourlyPrice = bootstackServerDailyPrice / hoursInDay,
+  viewBy = 'vms',
+  billingPeroid = 'month',
+  uaServerHourlyCosts = {
+    small: 75000 / hoursInYear,
+    medium: 180000 / hoursInYear,
+    large: 350000 / hoursInYear
+  },
+  smallThreshold = 101,
+  mediumThreshold = 501,
+  /* general elements */
+  calculatorForm = document.querySelector('#calculator-form'),
+  vmsFieldset = document.querySelector('#vms'),
+  serversFieldset = document.querySelector('#servers'),
+
+  /* Input elements */
+  numberOfStaffInput = document.querySelector('#number-of-staff'),
+  annualSalaryThousandsInput = document.querySelector('#staff-annual-salary'),
+  numberOfServersInput = document.querySelector('#number-of-servers'),
+  numberOfVmsInput = document.querySelector('#number-of-vms'),
+  /* Radio input selectors */
+  vmsOrServersInputSelector = '[name=vms-or-servers]:checked',
+  billingPeriodInputSelector = '[name=billing-period]:checked',
+
+  /* Output elements */
+  bootstackCostOutput = document.querySelector('#bootstack-cost'),
+  selfBuiltCostOutput = document.querySelector('#self-built-cost'),
+  billingPeriodOutputs = document.querySelectorAll('.billing-period'),
+  selfBuiltStaffCostOutputs = document.querySelectorAll('.self-built-staff-cost'),
+  selfBuiltUACostOutputs = document.querySelectorAll('.self-built-ua-cost'),
+  uaSupportCostOutput = document.querySelector('#ua-support-cost-output'),
+  numServerOrVmsOutput = document.querySelector('#num-servers-or-vms-output'),
+  serversOrVmsOutput = document.querySelector('#servers-or-vms-output');
+
+  // Function to update the servers variables and update calculations
+  function update() {
+      var numberOfStaff = parseInt(numberOfStaffInput.value),
+          annualSalary = parseInt(annualSalaryThousandsInput.value) * 1000,
+          serversOrVms = document.querySelector(vmsOrServersInputSelector).value,
+          billingPeriod = document.querySelector(billingPeriodInputSelector).value,
+          annualStaffCost = numberOfStaff * annualSalary,
+          uaCost = 0,
+          numberOfUnits = 0;
+
+      switch(billingPeroid) {
+        case 'hour': staffCost = annualStaffCost / hoursInYear; break;
+        case 'month': staffCost = annualStaffCost / monthsInYear; break;
+        case 'year': staffCost = annualStaffCost; break;
+      }
+
+      if (serversOrVms === 'VMs') {
+          // VM calculations
+          vmsFieldset.classList.remove('is-hidden');
+          serversFieldset.classList.add('is-hidden');
+
+          numberOfUnits = parseInt(numberOfVmsInput.value);
+
+          var uaHourlyCost = numberOfUnits * uaPriceVm,
+              vmCostPerHour = numberOfUnits * vmPerHour;
+
+          switch(billingPeroid) {
+            case 'hour':
+              bootstackCost = vmCostPerHour;
+              uaCost = uaHourlyCost;
+              break;
+            case 'month':
+              bootstackCost = vmCostPerHour * hoursInMonth;
+              uaCost = uaHourlyCost * hoursInMonth;
+              break;
+            case 'year':
+              bootstackCost = vmCostPerHour * hoursInYesr;
+              uaCost = uaHourlyCost * hoursInYear;
+              break;
+          }
+      } else if (serversOrVms === 'Servers') {
+          // Server calculations
+          vmsFieldset.classList.add('is-hidden');
+          serversFieldset.classList.remove('is-hidden');
+
+          numberOfUnits = parseInt(numberOfServersInput.value);
+
+          if (numberOfUnits < smallThreshold ) {
+            uaServerHourlyCost = uaServerHourlyCosts.small;
+          } else if (numberOfUnits < mediumThreshold ) {
+            uaServerHourlyCost = uaServerHourlyCosts.medium;
+          } else {
+            uaServerHourlyCost = uaServerHourlyCosts.large;
+          }
+
+          var serverHourlyCost = numberOfUnits * bootstackServerHourlyPrice;
+
+          switch(billingPeroid) {
+            case 'hour':
+              bootstackCost = serverHourlyCost;
+              uaCost = uaServerHourlyCost;
+              break;
+            case 'month':
+              bootstackCost = serverHourlyCost * hoursInMonth;
+              uaCost = uaServerHourlyCost * hoursInMonth;
+              break;
+            case 'year':
+              bootstackCost = serverHourlyCost * hoursInYesr;
+              uaCost = uaServerHourlyCost * hoursInYear;
+              break;
+          }
+      } else {
+        throw "Error in cloud.calculator: Erroneous value for serversOrVMs: " + serversOrVms;
+      }
+
+      billingPeriodOutputs.forEach(function(elem) {elem.innerText = billingPeriod;});
+      numServerOrVmsOutput.innerText = numberOfUnits;
+      serversOrVmsOutput.innerText = serversOrVms;
+      selfBuiltStaffCostOutputs.forEach(function(elem) {elem.innerText = cloud.formatPrice(staffCost);});
+      selfBuiltUACostOutputs.forEach(function(elem) {elem.innerText = cloud.formatPrice(uaCost);});
+      bootstackCostOutput.innerText = cloud.formatPrice(bootstackCost);
+      selfBuiltCostOutput.innerText = cloud.formatPrice(uaCost + staffCost);
+  }
+
+  // Update everything when input changes
+  calculatorForm.addEventListener('change', update);
+  calculatorForm.addEventListener('input', update);
+  update();
+};

--- a/templates/cloud/openstack/managed-cloud/index.html
+++ b/templates/cloud/openstack/managed-cloud/index.html
@@ -60,10 +60,8 @@
               <div class="slider-area" id="how-many-vms">
                   <fieldset class="slider-value">
                       <label for="amount-vms" class="off-left">VMs</label>
-                      <input type="number" min="0" max="5000" id="amount-vms" name="amount_1" value="10" class="amount-input" />
+                      <input type="number" min="0" max="5000" id="amount-vms" name="amount_1" value="10" class="add-slider amount-input" />
                   </fieldset>
-
-                  <div class="slider-container"></div>
 
                   <!--  Hidden fields -->
                   <input type="hidden" name="item_name_1" value="VMs" />
@@ -76,10 +74,8 @@
               <div class="slider-area" id="how-many-servers">
                   <fieldset class="slider-value">
                       <label for="amount-servers" class="off-left">Servers</label>
-                      <input type="number" min="0" max="5000" id="amount-servers" name="amount_2" value="10" class="amount-input" />
+                      <input type="number" min="0" max="5000" id="amount-servers" name="amount_2" value="10" class="add-slider amount-input" />
                   </fieldset>
-
-                  <div class="slider-container"></div>
 
                   <!--  Hidden fields -->
                   <input type="hidden" name="item_name_2" value="Servers">
@@ -268,6 +264,10 @@
 {% endblock content %}
 
 {% block footer_extra %}
+<script src="{% versioned_static 'js/forms.js' %}"></script>
+<script>
+    forms.addSliders('.add-slider');
+</script>
 <script>
 /**
  * Ubuntu YUI sliders
@@ -363,46 +363,13 @@ var daysInYear = 365,
     groupedTabbed = Y.one('.grouped-tabbed');
     groupedTabbed.all('.grouped-tabbed__item').on('click', updateBillingPeriod);
 
-    // Sliders
-    vmsSlider = new Y.Slider({min: 0, max: 5000, thumbUrl: '#'});
-    serversSlider = new Y.Slider({min: 7, max: 1000, thumbUrl: '#'});
-    var sliders = [vmsSlider, serversSlider];
-
-    vmsInput.setData({slider: vmsSlider, area: vmsArea});
-    serversInput.setData({slider: serversSlider, area: serversArea});
-
-    // Update sliders
-    Y.each(inputs, function(input) {
-        // Setup input area
-        input.on(['change', 'keyup', 'mouseup'], updateSliderFromInput);  // Update slider when input changes
-
-        // Update slider
-        slider = input.getData('slider')
-        slider.set('input', input); // Link input to slider
-        slider.set('container', input.getData('area').one('.slider-container')); // Link container to slider itself
-        slider.after("valueChange", updateInputFromSlider); // Update input when slider updates
-        slider.after("valueChange", updateSliderBackground);
-        slider.after("valueChange", render);
-
-        // Render the slider
-        slider.render(slider.get('container')); // Render the sliders into their containers
-    });
-
     checkboxContainer.all('input[type=radio]').on('change', updateViewBy);
 
     calculatorForm.on(['change', 'keyup'], render);  // Update slider when input changes
 
-    calculatorForm.setData('sliders', sliders);
-
     // When the window resizes, resize sliders
     var yuiWindow = Y.one('window');
     yuiWindow.setData('calculatorForm', calculatorForm);
-    yuiWindow.on('resize', function(resizeEvent) {resizeSliders(calculatorForm)});
-    resizeSliders(calculatorForm);
-
-    // Initial values
-    vmsSlider.setValue(100);
-    serversSlider.setValue(60);
 });
 
 // Function to update the servers variables and update calculations

--- a/templates/cloud/openstack/managed-cloud/index.html
+++ b/templates/cloud/openstack/managed-cloud/index.html
@@ -46,106 +46,105 @@
             <ul class="checkbox-vms-servers__list">
                 <li class="checkbox-vms-servers__list-item">
                     <label for="radio-servers">Servers</label>
-                    <input type="radio" id="radio-servers" name="vms-or-servers" value="servers" checked />
+                    <input type="radio" id="radio-servers" name="vms-or-servers" value="Servers" checked />
                 </li>
                 <li class="checkbox-vms-servers__list-item">
                     <label for="radio-vms">VMs</label>
-                    <input type="radio" id="radio-vm//s" name="vms-or-servers" value="vms" />
+                    <input type="radio" id="radio-vm//s" name="vms-or-servers" value="VMs" />
                 </li>
             </ul>
         </div>
-        <div class="four-col grey-box box" id="vms-input">
+        <div class="four-col grey-box box" id="vms">
             <h3 class="sub-heading">Number of VMs</h3>
-            <div class="sliders-container">
-              <div class="slider-area" id="how-many-vms">
-                  <fieldset class="slider-value">
-                      <label for="amount-vms" class="off-left">VMs</label>
-                      <input type="number" min="0" max="5000" id="amount-vms" name="amount_1" value="10" class="add-slider amount-input" />
-                  </fieldset>
+            <div class="slider-area" id="how-many-vms">
+              <label for="number-of-vms" class="off-left">VMs</label>
+              <input type="number" min="0" max="5000" id="number-of-vms" name="amount_1" value="100" class="add-slider amount-input" />
 
-                  <!--  Hidden fields -->
-                  <input type="hidden" name="item_name_1" value="VMs" />
-              </div>
+              <!--  Hidden fields -->
+              <input type="hidden" name="item_name_1" value="VMs" />
             </div>
         </div>
-        <div class="four-col grey-box box is-hidden" id="servers-input">
+        <div class="four-col grey-box box is-hidden" id="servers">
             <h3 class="sub-heading">Number of servers</h3>
-            <div class="sliders-container">
-              <div class="slider-area" id="how-many-servers">
-                  <fieldset class="slider-value">
-                      <label for="amount-servers" class="off-left">Servers</label>
-                      <input type="number" min="0" max="5000" id="amount-servers" name="amount_2" value="10" class="add-slider amount-input" />
-                  </fieldset>
+            <div class="slider-area" id="how-many-servers">
+                <label for="number-of-servers" class="off-left">Servers</label>
+                <input type="number" min="0" max="1000" id="number-of-servers" name="amount_2" value="60" class="add-slider amount-input" />
 
-                  <!--  Hidden fields -->
-                  <input type="hidden" name="item_name_2" value="Servers">
-              </div>
+                <!--  Hidden fields -->
+                <input type="hidden" name="item_name_2" value="Servers">
             </div>
         </div>
         <div class="four-col grey-box box last-col">
             <h3 class="sub-heading">Billing period</h3>
             <ul class="grouped-tabbed">
                 <li class="grouped-tabbed__item">
-                    <a href="#" class="grouped-tabbed__button" data-billing="hour">Hour</a>
+                  <input class="grouped-tabbed__input" type="radio" name="billing-period" id="hourly-billing" value="hour" />
+                  <label class="grouped-tabbed__button" for="hourly-billing">Hour</a>
                 </li>
                 <li class="grouped-tabbed__item">
-                    <a href="#" class="grouped-tabbed__button is-active" data-billing="month">Month</a>
+                  <input class="grouped-tabbed__input" type="radio" name="billing-period" id="monthly-billing" checked="checked" value="month" />
+                  <label class="grouped-tabbed__button" for="monthly-billing">Month</a>
                 </li>
                 <li class="grouped-tabbed__item">
-                    <a href="#" class="grouped-tabbed__button" data-billing="year">Year</a>
+                  <input class="grouped-tabbed__input" type="radio" name="billing-period" id="yearly-billing" value="year" />
+                  <label class="grouped-tabbed__button" for="yearly-billing">Year</a>
                 </li>
             </ul>
         </div>
 
         <div class="equal-height">
             <div class="equal-height__item six-col box result" id="bootstack-section">
-                <header class="result__header">
-                    <div class="result__header-banner">
-                      <h4 class="result__header-sub-heading">BootStack managed cloud</h4>
-                    </div>
-                    <h3 class="result__header-amount"><span class="calculated-amount">&mdash;</span> per <span class="selected-duration">month</span></h3>
-                    <p class="note">BootStack cost including Ubuntu Advantage support</p>
-                </header>
-                <div class="result__content">
-                    <p class="intro">Canonical builds, manages and operates your cloud 24x7.</p>
-                    <ul class="no-margin-bottom">
-                        <li>Built with Canonical OpenStack, the world&rsquo;s leading open cloud platform</li>
-                        <li>Your choice of hardware, certified by Canonical for Ubuntu and OpenStack</li>
-                        <li>A suite of management tools and the training you need to take control</li>
-                    </ul>
+              <header class="result__header">
+                <div class="result__header-banner">
+                  <h4 class="result__header-sub-heading">BootStack managed cloud</h4>
                 </div>
-                <footer class="result__footer">
-                    <h3 class="result__footer-title">Price includes Ubuntu Advantage</h3>
-                    <p>Commercial support for your cloud from the experts at&nbsp;Canonical.</p>
-                </footer>
+                <h3 class="result__header-amount"><span id="bootstack-cost">&mdash;</span> per <span class="billing-period">month</span></h3>
+                <p class="note">BootStack cost including Ubuntu Advantage support</p>
+              </header>
+              <div class="result__content">
+                <p class="intro">Canonical builds, manages and operates your cloud 24x7.</p>
+                <ul class="no-margin-bottom">
+                  <li>Built with Canonical OpenStack, the world&rsquo;s leading open cloud platform</li>
+                  <li>Your choice of hardware, certified by Canonical for Ubuntu and OpenStack</li>
+                  <li>A suite of management tools and the training you need to take control</li>
+                </ul>
+              </div>
+              <footer class="result__footer">
+                <h3 class="result__footer-title">Price includes Ubuntu Advantage</h3>
+                <p>Commercial support for your cloud from the experts at&nbsp;Canonical.</p>
+              </footer>
             </div>
 
             <div class="equal-height__item six-col last-col box result" id="diy-section">
                 <header class="result__header">
-                    <div class="result__header-banner">
-                        <h4 class="result__header-sub-heading">Self-built and managed cloud</h4>
-                    </div>
-                    <h3 class="result__header-amount"><span class="calculated-amount">&mdash;</span> per <span class="selected-duration">month</span></h3>
-                    <p class="note">Staff cost <span class="result__header-calculation--staff">$0</span> plus Ubuntu Advantage support cost <span class="result__header-calculation--ua">$0</span></p>
+                  <div class="result__header-banner">
+                    <h4 class="result__header-sub-heading">Self-built and managed cloud</h4>
+                  </div>
+                  <h3 class="result__header-amount"><span id="self-built-cost">&mdash;</span> per <span class="billing-period">month</span></h3>
+                  <p class="note">Staff cost <span class="self-built-staff-cost">$0</span> plus Ubuntu Advantage support cost <span class="self-built-ua-cost">$0</span></p>
                 </header>
                 <div class="result__content">
-                    <p class="intro">Your in-house staff costs to operate your cloud 24x7: <span class="result__header-calculation--staff">$0</span> per <span class="selected-duration">month</span></p>
-                    <ul class="no-bullets">
-                        <li>
-                            <input type="number" min="0" max="50" id="amount-staff" name="amount_3" value="6" class="input-staff" />
-                            <label for="amount-staff">Staff required</label>
-                        </li>
-                        <li>
-                            <input type="number" min="0" max="250" id="amount-salary" name="amount_4" value="100" class="input-salary" />
-                            <span class="input-helper">$k</span>
-                            <label for="amount-salary">Average annual salary</label>
-                        </li>
-                    </ul>
-                    <p class="note">• Average salary data obtained from Indeed.com for&nbsp;the&nbsp;USA</p>
+                  <p class="intro">Your in-house staff costs to operate your cloud 24x7: <span class="self-built-staff-cost">$0</span> per <span class="billing-period">month</span></p>
+                  <ul class="no-bullets">
+                    <li>
+                      <input type="number" min="0" max="50" id="number-of-staff" name="amount_3" value="6" class="input-staff" />
+                      <label for="number-of-staff">Staff required</label>
+                    </li>
+                    <li>
+                      <input type="number" min="0" max="250" id="staff-annual-salary" name="amount_4" value="100" class="input-salary" />
+                      <span class="input-helper">$k</span>
+                      <label for="staff-annual-salary">Average annual salary</label>
+                    </li>
+                  </ul>
+                  <p class="note">• Average salary data obtained from Indeed.com for&nbsp;the&nbsp;USA</p>
                 </div>
                 <footer class="result__footer">
-                    <h3 class="result__footer-title">Ubuntu Advantage support:<br/> <span class="result__header-calculation--ua">$0</span> per <span class="selected-duration">month</span> for <span class="selected-amount"></span> <span class="selected-type"></span></h3>
-                    <p>Supplement your team with commercial support for your cloud from the experts at&nbsp;Canonical.</p>
+                  <h3 class="result__footer-title">
+                    Ubuntu Advantage support:<br/>
+                    <span class="self-built-ua-cost">$0</span> per <span class="billing-period">month</span>
+                    for <span id="num-servers-or-vms-output"></span> <span id="servers-or-vms-output"></span>
+                  </h3>
+                  <p>Supplement your team with commercial support for your cloud from the experts at&nbsp;Canonical.</p>
                 </footer>
             </div>
         </div>
@@ -265,257 +264,9 @@
 
 {% block footer_extra %}
 <script src="{% versioned_static 'js/forms.js' %}"></script>
+<script src="{% versioned_static 'js/cloud.js' %}"></script>
 <script>
     forms.addSliders('.add-slider');
-</script>
-<script>
-/**
- * Ubuntu YUI sliders
- *
- * This class controls the sliders to distribute the donation
- *
- * @project     Ubuntu Core Front-End Framework
- * @author      Web Team at Canonical Ltd
- * @copyright   2012 Canonical Ltd
- *
- **/
-
-
-var daysInYear = 365,
-    monthsInYear = 12,
-    hoursInDay = 24,
-    vmPerHour = 0.05,
-    uaPriceVm = 0.03,
-    bootstackPriceServerHour = 15 / hoursInDay,
-    viewBy = 'vms',
-    billingPeroid = 'month',
-    vmsSlider,
-    serversSlider,
-    diyAmountSpan,
-    bootstackAmountSpan,
-    staffNoPeople,
-    staffSalary,
-    noOfVms,
-    noOfServers,
-    noOfVmsInput,
-    noOfServersInput,
-    staffInput,
-    salaryInput,
-    checkboxContainer,
-    uAServerPriceHour,
-    vmsInputSection,
-    serversInputSection,
-    groupedTabbed,
-    diyPeriodSpan,
-    bootstackPeriodSpan,
-    diyStaffCost,
-    diyUACost,
-    selectedAmountSpan,
-    selectedTypeSpan,
-    uAAZServersSmall = {
-      threshold: 101,
-      amount: 75000
-    },
-    uAAZServersMedium = {
-      threshold: 501,
-      amount: 180000
-    },
-    uAAZServersLarge = {
-      amount: 350000
-    },
-    billingOffset = {
-      'hour': 1,
-      'month': hoursInDay * 30,
-      'year': hoursInDay * daysInYear
-    };
-
- YUI({bootstrap: false}).use('slider', function (Y) {
-
-    diyAmountSpan = Y.one('#diy-section .calculated-amount');
-    bootstackAmountSpan = Y.one('#bootstack-section .calculated-amount');
-    diyPeriodSpan = Y.all('#diy-section .selected-duration');
-    bootstackPeriodSpan = Y.one('#bootstack-section .selected-duration');
-    staffInput = Y.one('#amount-staff');
-    salaryInput = Y.one('#amount-salary');
-    noOfServersInput = Y.one('#amount-servers');
-    noOfVmsInput = Y.one('#amount-vms');
-    checkboxContainer = Y.one('.checkbox-vms-servers__list');
-    vmsInputSection = Y.one('#vms-input');
-    serversInputSection = Y.one('#servers-input');
-    diyStaffCost = Y.all('.result__header-calculation--staff');
-    diyUACost = Y.all('.result__header-calculation--ua');
-    viewBy = checkboxContainer.one('input[type=radio][checked]').get('value');
-    selectedAmountSpan = Y.one('.selected-amount'),
-    selectedTypeSpan = Y.one('.selected-type');
-
-    // Setup the calculator form
-    var calculatorForm = Y.one('#calculator-form');
-
-    // Slider areas
-    var vmsArea = Y.one('#how-many-vms');
-    var serversArea = calculatorForm.one('#how-many-servers');
-
-    // Create slider input
-    var vmsInput = vmsArea.one('#amount-vms');
-    var serversInput = serversArea.one('#amount-servers');
-    var inputs = [vmsInput, serversInput];
-
-    groupedTabbed = Y.one('.grouped-tabbed');
-    groupedTabbed.all('.grouped-tabbed__item').on('click', updateBillingPeriod);
-
-    checkboxContainer.all('input[type=radio]').on('change', updateViewBy);
-
-    calculatorForm.on(['change', 'keyup'], render);  // Update slider when input changes
-
-    // When the window resizes, resize sliders
-    var yuiWindow = Y.one('window');
-    yuiWindow.setData('calculatorForm', calculatorForm);
-});
-
-// Function to update the servers variables and update calculations
-function render() {
-
-    noOfVms = parseInt(noOfVmsInput.get('value'));
-    noOfServers = parseInt(noOfServersInput.get('value'));
-    staffNoPeople = parseInt(staffInput.get('value'));
-    staffSalary = parseInt(salaryInput.get('value'));
-
-    var diyAmount = bootstackAmount = uAServerPriceHour = uaCost = 0;
-
-    var staffCost = staffNoPeople * staffSalary * 1000;
-
-    if (viewBy === 'vms') {
-        // VM calculations
-        vmsInputSection.removeClass('is-hidden');
-        serversInputSection.addClass('is-hidden');
-
-        uaCost = noOfVms * uaPriceVm * billingOffset[billingPeroid];
-
-        switch(billingPeroid) {
-            case 'hour':
-                staffCost = staffCost / daysInYear / hoursInDay;
-            break;
-            case 'month':
-                staffCost = staffCost / monthsInYear;
-            break;
-            default:
-                diyAmount = '-';
-            break;
-        }
-        bootstackAmount = (noOfVms * vmPerHour) * billingOffset[billingPeroid];
-        selectedAmountSpan.set('text', noOfVms);
-        selectedTypeSpan.set('text', 'VMs');
-    } else {
-        // Server calculations
-        vmsInputSection.addClass('is-hidden');
-        serversInputSection.removeClass('is-hidden');
-
-        if (noOfServers < uAAZServersSmall.threshold ) {
-            uAServerPriceHour = uAAZServersSmall.amount / daysInYear / hoursInDay;
-        } else if (noOfServers < uAAZServersMedium.threshold ) {
-            uAServerPriceHour = uAAZServersMedium.amount / daysInYear / hoursInDay;
-        } else {
-            uAServerPriceHour = uAAZServersLarge.amount / daysInYear / hoursInDay;
-        }
-
-        var uaCost = uAServerPriceHour * billingOffset[billingPeroid];
-
-        switch(billingPeroid) {
-            case 'hour':
-                staffCost = staffCost / daysInYear / hoursInDay;
-            break;
-            case 'month':
-                staffCost = staffCost / monthsInYear;
-            break;
-            default:
-                diyAmount = '-';
-            break;
-        }
-        bootstackAmount = (noOfServers * bootstackPriceServerHour) * billingOffset[billingPeroid];
-        selectedAmountSpan.set('text', noOfServers);
-        selectedTypeSpan.set('text', 'servers');
-    }
-    diyAmount = uaCost + staffCost;
-
-    diyStaffCost.set('text', formatPrice(staffCost));
-    diyUACost.set('text', formatPrice(uaCost));
-    bootstackAmountSpan.set('text', formatPrice(bootstackAmount));
-    diyAmountSpan.set('text', formatPrice(diyAmount));
-}
-
-// Function to update the selected Billing Period
-function updateBillingPeriod(event) {
-  event.preventDefault();
-  var target = event.target;
-  groupedTabbed.all('.grouped-tabbed__button').removeClass('is-active');
-  target.addClass('is-active');
-  billingPeroid = target.getData('billing');
-  diyPeriodSpan.set('text', billingPeroid);
-  bootstackPeriodSpan.set('text', billingPeroid);
-  render();
-}
-
-// Function to update the viewBy variable
-function updateViewBy(event) {
-  viewBy = event.target.get('value');
-  render();
-}
-
-// Function to update the input value from the Slider value
-function updateInputFromSlider(event) {
-    // Update input field and recalculate
-    var slider = event.target;
-    slider.get('input').set( "value", slider.getValue() );
-}
-
-function updateSliderFromInput(event) {
-    var input = event.target;
-    // Input can't be more than 10000
-    if (input.get('value') > 10000) {
-        input.set('value', 10000);
-    }
-    // Or less than zero
-    if (input.get('value') < 0) {
-        input.set('value', 0);
-    }
-    var value = parseInt(input.get('value')) || 0;
-    var slider = input.getData('slider');
-    slider.setValue(value);
-}
-
-function updateSliderBackground(event) {
-    // Get values
-    var slider = event.target;
-    var value = slider.getValue();
-    var max = slider.get('max');
-    var min = slider .get('min');
-    var percentage = ((value - min) / (max - min)) * 100;
-    var sliderRail = slider.get('container').one('.yui3-slider-rail');
-    sliderRail.setStyle('background', 'linear-gradient(to left, #E1DAD2 ' + (100 - percentage) + '%, #DD4713 0%)');
-}
-
-// format currency nicely
-function formatPrice(number) {
-    numberWithCommas = Math.ceil(number).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    amount = '$' + numberWithCommas;
-    amount = amount.replace('$-', '-$');
-    return amount;
-}
-
-
-// Recalculate the sliders' lengths
-function resizeSliders(form) {
-    // Calculate length
-    var container = form.one('.sliders-container');
-    var widthString = container.getComputedStyle('width');
-    var width = widthString.replace('px', '');
-    var containerWidth = parseInt(width);
-    var inputWidth = form.one('.slider-value').get('offsetWidth');
-    // sliders should sit alongside inputs with padding
-    var sliderLength = containerWidth - 20 - inputWidth;
-
-    vmsSlider.set('length', sliderLength + 'px');
-}
-
+    cloud.calculator();
 </script>
 {% endblock footer_extra %}

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -160,9 +160,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		var root = document.documentElement;
 		root.className += " opera-mini";
 	}
-</script>
-<script src="{{ ASSET_SERVER_URL }}40d25181-yui-combined.min.js"></script>
-<script>
 	if(!core){ var core = {}; }
 	core.globalPrepend = 'body';
 </script>


### PR DESCRIPTION
- Rewrite Bootstack calculator to remove dependence on YUI
- Tweak styling to make number inputs wider, so numbers into the thousands display properly
- Simplify JS a fair bit
- Move calculator JS out into a `cloud.js` file
- Remove YUI from site!!!! (why wait!)

QA
--

`make run`

- Visit <http://127.0.0.1:8001/cloud/openstack/managed-cloud#calculator-form>. Play around a lot. Compare numbers to live.
- Browse around the site generally a bit looking for JS errors that aren't on live.
- I've tested this on Chrome and Firefox. It would be great to test it in any IEs we expect it to work in - IE9 maybe? And check IE8 seems to have a reasonable fall-back.