### PR TITLE
add left/right margin to blockquote in things

### DIFF
--- a/static/css/section/_things.scss
+++ b/static/css/section/_things.scss
@@ -17,6 +17,12 @@
     background: $light-grey;
     color: $cool-grey;
 
+    .pull-quote {
+      @media only screen and (min-width: $breakpoint-medium) {
+        margin: 0 .6em;
+      }
+    }
+
     p,
     .pull-quote cite {
       color: $cool-grey;
@@ -199,16 +205,16 @@ body.internet-of-things-developers {
   .row-hero__image {
     width: 200px;
     @media only screen and (min-width: $breakpoint-medium) {
-      width: auto;  
+      width: auto;
     }
   }
- 
+
   @media only screen and (min-width: $breakpoint-medium) {
     #main-content .row-hero h1 {
       margin-top: 40px;
     }
   }
-  
+
   .list-partners li {
     font-size: 1em;
   }
@@ -216,20 +222,18 @@ body.internet-of-things-developers {
 
 .row-cta--digital-signage {
   background: url('#{$asset-server}68b1a2e2-banner_pixels05.png') center center no-repeat;
-  
+
   @media only screen and (min-width: $breakpoint-medium) {
     background-size: cover;
   }
-  
+
   a {
     color: $white;
     border-bottom: 1px solid white;
     text-decoration: none;
   }
-  
+
   .button--secondary {
     color: $cool-grey;
   }
 }
-
- 


### PR DESCRIPTION
## Done

* added a little left/right margin on blockquotes on the iot/partners casestudies row for tablet up

## QA

1. go to /internet-of-things/partners and see the quotes align with the headings in desktop and are ok on tablet and phone

## Issue / Card

Fixes #345 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/18616014/0d4b905a-7dac-11e6-9087-a55bfc970ea0.png)

