### PR TITLE
lint server.scss and fixup logos on hyperscale

### DIFF
--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -1,213 +1,116 @@
-/*	@section server
---------------------------------------------------------------
-    Contents:
-        @section general
-        @section server-services
--------------------------------------------------------------- */
+@charset 'UTF-8';
 
-/*	@section general
--------------------------------------------------------------- */
+// ---------------------------------------------------------------
+// ---------------------------------------------------------------
+//
+//  Project:		Ubuntu Front-End Server section
+//  Author:			Web Team at Canonical Ltd
+//  Last edited by: Peter Mahnke
+//  Last edited on: 19 September 2016
+//
+// ---------------------------------------------------------------
+// ---------------------------------------------------------------
 
-body.server {
+// @global server
+.server {
 
-  .row-hero { /* First bit of content on a page, normally contains h1 and sometimes a bit of blurb */
+  .row-hero {
     position: relative;
-
-    h2 {
-      color: $warm-grey;
-      padding-top: 20px;
-    }
   }
 
-  tfoot th {
-    font-weight: bold;
-  }
-
-  .button-right {
-    margin-top: 18px;
-    margin-bottom: 0;
-  }
-
-  .row-landscape img {
-    height: auto;
-    max-width: 100%;
-  }
-
-  .row-community {
-    margin-bottom: 0;
-    border-bottom: 0;
-    padding: 40px 20px;
-  }
-
-  .row-community .nine-col {
-    background: #fff;
-  }
-
-  .box-padded ul.inline-icons {
-    margin-bottom: 0;
-  }
-}
-
-.row-juju-maas div {
-  padding-bottom: 0;
-}
-
-/*	@section server-services
--------------------------------------------------------------- */
-body.server-services .row-hero {
-  background-image: none;
-  border: 0;
-  padding-bottom: 0;
-}
-
-body.server-services .row-hero h2 {
-  background: none;
-  color: inherit;
-  padding: 0;
-  text-align: left;
-}
-
-body.server-services .packages {
-  margin-bottom: 20px;
-}
-
-body.server-services .packages h2 {
-  background: #efeeec url('#{$asset-server}87667959-bg-servicesserver-owl-125x101.png') no-repeat 20px 50%;
-  width: 45.5%;
-  padding-top: 85px;
-  padding-bottom: 77px;
-}
-
-body.server-services .packages dd {
-  min-height: 10em;
-}
-
-body.server-services .packages dd.price {
-  min-height: 0;
-}
-
-body.server-services .packages .price-annual  {
-  top: 220px;
-}
-
-body.server-services .row-ubuntu-advantage {
-  padding-bottom: 0;
-}
-
-body.server-services .row-ubuntu-advantage h3 {
-  font-size: 1.21875em;
-}
-
-body.server-services .row-ubuntu-advantage .list-details {
-  margin-bottom: 0;
-}
-
-body.server-services .row-ubuntu-advantage li.first {
-  height: 38.7em;
-}
-
-body.server-services .row-blockquote {
-  background: #e2d4dc;
-  padding-top: $gutter-width;
-  margin-bottom: 0;
-  padding-bottom: $gutter-width/2;
-}
-
-body.server-services .row-blockquote p.last {
-  padding-left: 25px;
-  display: block;
-  float: left;
-}
-
-body.server-services .row-blockquote p a {
-  font-size: 1em;
-}
-
-body.server-services .row-enterprise {
-  padding-top: $gutter-width;
-  margin-bottom: 0;
-  overflow: hidden;
-}
-
-body.server-services .row-ubuntu-advantage {
-  padding-top: 30px;
-}
-
-body.server-services .row-enterprise .quote-canonical {
-  margin-right: 20px;
-  padding: 20px 40px 0 80px;
-}
-
-body.server-services .row-methodology {
-  background: #e2d4dc;
-  padding-top: $gutter-width;
-}
-
-body.server-services .row-methodology .arrow-left {
-  bottom: auto;
-  top: 20px;
-}
-
-body.server-hyperscale h1 {
-  float: none;
-  margin-bottom: 18px;
-}
-
-body.server-contact-us .row-hero h2,
-body.server-thank-you .row-hero h2 {
-  color: #333;
-  padding-top: 0;
-}
-
-body.server-hyperscale {
-  .partner-logo {
-    margin-bottom: 10px;
-  }
-}
-
-/* Medium / Tablet viewport
--------------------------------------------------------------- */
-@media only screen and (min-width : 769px) {
-    body.server {
-        .box-padded-feature {
-            .six-col {
-              border-right: 1px dotted $warm-grey;
-            }
-
-            .six-col.last-col {
-              border-right: 0;
-            }
-
-            .border-bottom {
-              border-bottom: 1px dotted $warm-grey;
-              padding-bottom: 10px;
-              margin-bottom: 10px;
-            }
-        }
-    }
-    body.server-hyperscale {
-      .partner-logo {
-        height: 105px;
+  .box-padded-feature {
+    @media only screen and (min-width : $breakpoint-medium) {
+      .six-col {
+        border-right: 1px dotted $warm-grey;
       }
 
-      .partner-logo img {
+      .six-col.last-col {
+        border-right: 0;
+      }
+
+      .border-bottom {
+        border-bottom: 1px dotted $warm-grey;
+        margin-bottom: 10px;
+        padding-bottom: 10px;
+      }
+    }
+  }
+}
+
+// @section /server overview
+.server-home {
+
+  .row-juju-maas div {
+    padding-bottom: 0;
+  }
+}
+
+// @subsection /server/management
+.server-management {
+
+  .row-community {
+    @media only screen and (min-width : $breakpoint-medium) {
+      border-bottom: 0;
+      margin-bottom: 0;
+      padding: 40px 20px;
+
+      .nine-col {
+        background: #fff;
+      }
+    }
+  }
+}
+
+// @subsection /server/hyperscale
+.server-hyperscale {
+
+  h1 {
+    float: none;
+    margin-bottom: 18px;
+  }
+
+  .partner-logo {
+    margin: 0 auto 10px;
+
+    @media only screen and (min-width : $breakpoint-medium) {
+      height: 105px;
+
+      img {
         position: relative;
         top: 50%;
         -webkit-transform: translateY(-50%);
         -ms-transform: translateY(-50%);
         transform: translateY(-50%);
       }
+    }
+  }
 
-      .welcome-hyperscale {
-        background-image: url("#{$asset-server}ab812f69-image-server-hyperscale.svg");
-        background-repeat: no-repeat;
-        background-position: 575px center;
-      }
+  .welcome-hyperscale {
+    @media only screen and (min-width : $breakpoint-medium) {
+      background-image: url("#{$asset-server}ab812f69-image-server-hyperscale.svg");
+      background-position: 575px center;
+      background-repeat: no-repeat;
     }
-    html.no-svg,
-    html.opera-mini {
-        body.server-hyperscale .welcome-hyperscale {
-          background-image: url("#{$asset-server}b47ff24b-image-server-hyperscale.png");
-        }
+  }
+}
+
+// @subsection /server/contact-us
+.server-contact-us {
+
+  .row-hero {
+    h2 {
+      color: $cool-grey;
+      padding-top: 0;
     }
+  }
+}
+
+// @fix for opera and no-svg
+.no-svg,
+.opera-mini {
+  .server-hyperscale .welcome-hyperscale {
+    @media only screen and (min-width : $breakpoint-medium) {
+      background-image: url("#{$asset-server}b47ff24b-image-server-hyperscale.png");
+    }
+  }
 }

--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -35,14 +35,6 @@
   }
 }
 
-// @section /server overview
-.server-home {
-
-  .row-juju-maas div {
-    padding-bottom: 0;
-  }
-}
-
 // @subsection /server/management
 .server-management {
 

--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -5,8 +5,6 @@
 //
 //  Project:		Ubuntu Front-End Server section
 //  Author:			Web Team at Canonical Ltd
-//  Last edited by: Peter Mahnke
-//  Last edited on: 19 September 2016
 //
 // ---------------------------------------------------------------
 // ---------------------------------------------------------------
@@ -67,6 +65,19 @@
   h1 {
     float: none;
     margin-bottom: 18px;
+  }
+
+  .welcome-hyperscale {
+    @media only screen and (min-width : $breakpoint-medium) {
+      background-image: url('#{$asset-server}ab812f69-image-server-hyperscale.svg');
+      background-position: 575px center;
+      background-repeat: no-repeat;
+
+      .no-svg &,
+      .opera-mini & {
+        background-image: url("#{$asset-server}b47ff24b-image-server-hyperscale.png");
+      }
+    }
   }
 
   .partner-logo {

--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -50,10 +50,9 @@
     @media only screen and (min-width : $breakpoint-medium) {
       border-bottom: 0;
       margin-bottom: 0;
-      padding: 40px 20px;
 
       .nine-col {
-        background: #fff;
+        background: $white;
       }
     }
   }

--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -84,14 +84,6 @@
       }
     }
   }
-
-  .welcome-hyperscale {
-    @media only screen and (min-width : $breakpoint-medium) {
-      background-image: url("#{$asset-server}ab812f69-image-server-hyperscale.svg");
-      background-position: 575px center;
-      background-repeat: no-repeat;
-    }
-  }
 }
 
 // @subsection /server/contact-us
@@ -101,16 +93,6 @@
     h2 {
       color: $cool-grey;
       padding-top: 0;
-    }
-  }
-}
-
-// @fix for opera and no-svg
-.no-svg,
-.opera-mini {
-  .server-hyperscale .welcome-hyperscale {
-    @media only screen and (min-width : $breakpoint-medium) {
-      background-image: url("#{$asset-server}b47ff24b-image-server-hyperscale.png");
     }
   }
 }

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -134,28 +134,28 @@
     <h2>Hyperscale partners</h2>
     <ul class="partner-list no-bullets equal-height">
         <li class="six-col box equal-height">
-            <div class="partner-logo">
+            <div class="partner-logo align-center">
                 <img src="{{ ASSET_SERVER_URL }}cd5c35a3-partners-logo-hp.png" width="94" height="94" alt="" />
             </div>
             <p>Canonical has been involved in the development of Moonshot, HP&rsquo;s hyperscale platform, from its inception. Ubuntu is the only OS that supports the full range of HP Moonshot x86 and ARM Systems, announced by HP in April 2013, providing scale out innovation at speed.</p>
             <p><a href="http://partners.ubuntu.com/hp" class="external">Learn more</a></p>
         </li>
         <li class="box six-col last-col equal-height">
-            <div class="partner-logo">
+            <div class="partner-logo align-center">
                 <img src="{{ ASSET_SERVER_URL }}388b97f3-partners-logo-arm.png" width="150" height="45" alt="ARM logo" />
             </div>
             <p>ARM and Canonical have worked in close collaboration for a number of years to ensure that datacentres running advanced workloads such as distributed data processing or cloud infrastructure, run best on Ubuntu.</p>
             <p><a href="http://partners.ubuntu.com/arm" class="external">Learn more</a></p>
         </li>
         <li class="box six-col equal-height">
-            <div class="partner-logo">
+            <div class="partner-logo align-center">
                 <img src="{{ ASSET_SERVER_URL }}d0e5bf77-partners-logo-cavium.png" width="150" height="34" alt="Cavium logo" />
             </div>
             <p>Cavium is a provider of highly integrated semiconductor processors that enable intelligent networking, communications, storage, video and security applications within enterprise, datacentre, broadband/consumer, and access and service provider equipment.</p>
             <p><a href="http://www.cavium.com">Learn more&nbsp;&rsaquo;</a></p>
         </li>
         <li class="box six-col last-col equal-height">
-            <div class="partner-logo">
+            <div class="partner-logo align-center">
                 <img src="{{ ASSET_SERVER_URL }}ca664713-partners-logo-apm.svg" width="150" alt="Applied Micro Circuits Corporation logo" />
             </div>
             <p>Applied Micro Circuits Corporation is a global leader in computing and connectivity solutions for next-generation cloud infrastructure and data centers. AppliedMicro delivers silicon solutions that dramatically lower total cost of ownership.</p>

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -7,7 +7,7 @@
 
 
 {% block second_level_nav_items %}
-    {% include "templates/_nav_breadcrumb.html" with section_title="Server" page_title="Hyperscale"  %}
+{% include "templates/_nav_breadcrumb.html" with section_title="Server" page_title="Hyperscale"  %}
 {% endblock second_level_nav_items %}
 
 {% block header %}
@@ -132,30 +132,30 @@
 </div>
 <div class="row equal-height">
     <h2>Hyperscale partners</h2>
-    <ul class="partner-list no-bullets">
-        <li class="six-col box">
-            <div class="partner-logo text-center">
+    <ul class="partner-list no-bullets equal-height">
+        <li class="six-col box equal-height">
+            <div class="partner-logo">
                 <img src="{{ ASSET_SERVER_URL }}cd5c35a3-partners-logo-hp.png" width="94" height="94" alt="" />
             </div>
             <p>Canonical has been involved in the development of Moonshot, HP&rsquo;s hyperscale platform, from its inception. Ubuntu is the only OS that supports the full range of HP Moonshot x86 and ARM Systems, announced by HP in April 2013, providing scale out innovation at speed.</p>
             <p><a href="http://partners.ubuntu.com/hp" class="external">Learn more</a></p>
         </li>
-        <li class="box six-col last-col">
-            <div class="partner-logo text-center">
+        <li class="box six-col last-col equal-height">
+            <div class="partner-logo">
                 <img src="{{ ASSET_SERVER_URL }}388b97f3-partners-logo-arm.png" width="150" height="45" alt="ARM logo" />
             </div>
             <p>ARM and Canonical have worked in close collaboration for a number of years to ensure that datacentres running advanced workloads such as distributed data processing or cloud infrastructure, run best on Ubuntu.</p>
             <p><a href="http://partners.ubuntu.com/arm" class="external">Learn more</a></p>
         </li>
-        <li class="box six-col">
-            <div class="partner-logo text-center">
+        <li class="box six-col equal-height">
+            <div class="partner-logo">
                 <img src="{{ ASSET_SERVER_URL }}d0e5bf77-partners-logo-cavium.png" width="150" height="34" alt="Cavium logo" />
             </div>
             <p>Cavium is a provider of highly integrated semiconductor processors that enable intelligent networking, communications, storage, video and security applications within enterprise, datacentre, broadband/consumer, and access and service provider equipment.</p>
             <p><a href="http://www.cavium.com">Learn more&nbsp;&rsaquo;</a></p>
         </li>
-        <li class="box six-col last-col">
-            <div class="partner-logo text-center">
+        <li class="box six-col last-col equal-height">
+            <div class="partner-logo">
                 <img src="{{ ASSET_SERVER_URL }}ca664713-partners-logo-apm.svg" width="150" alt="Applied Micro Circuits Corporation logo" />
             </div>
             <p>Applied Micro Circuits Corporation is a global leader in computing and connectivity solutions for next-generation cloud infrastructure and data centers. AppliedMicro delivers silicon solutions that dramatically lower total cost of ownership.</p>
@@ -166,34 +166,40 @@
 
 {% include "shared/_ubuntu_advantage_whats_included.html" %}
 
+<div class="row">
+    <div class="twelve-col">
+        <h2 class="muted-heading">A selection of our hardware partners</h2>
+        <ul id="hardware-partners" class="inline-logos no-margin dynamic-logos"></ul>
+        <p class="align-center"><a href="/certification">View all certified hardware&nbsp;&rsaquo;</a></p>
+    </div>
+</div><!-- /.row -->
+
 <div class="row no-border">
-    <div class="twelve-col clearfix">
-        <div class="box-padded-feature">
-            <h3>Works with all your hardware and software</h3>
-                <div>
-                    <div class="six-col">
-                        <ul class="inline-icons clearfix">
-                            <li><img src="{{ ASSET_SERVER_URL }}31ce3f12-logo-dell-45x45.png" width="45" height="45" alt="Dell" /></li>
-                            <li><img src="{{ ASSET_SERVER_URL }}0985d8ac-logo-ibm-46x45.png" width="46" height="45" alt="IBM" /></li>
-                            <li><img src="{{ ASSET_SERVER_URL }}5bc8867e-logo-hp-41x45.png" width="41" height="45" alt="HP" /></li>
-                            <li><img src="{{ ASSET_SERVER_URL }}f2b90d0e-logo-intel-50x45.png" width="50" height="45" alt="Intel" /></li>
-                        </ul>
-                        <p><a href="/certification">View all certified hardware&nbsp;&rsaquo;</a></p>
-                    </div><!-- /.six-col -->
-                    <div class="six-col last-col">
-                        <ul class="inline-icons clearfix">
-                            <li><img src="{{ ASSET_SERVER_URL }}1dda56b0-logo-centrify-94x45.png" width="94" height="45" alt="Centrify" /></li>
-                            <li><img src="{{ ASSET_SERVER_URL }}ab23c143-logo-likewise-100x45.png" width="100" height="45" alt="Likewise" /></li>
-                            <li><img src="{{ ASSET_SERVER_URL }}0e002897-logo-openstack-45x45.png" width="45" height="45" alt="OpenStack" /></li>
-                            <li><img src="{{ ASSET_SERVER_URL }}17dd429b-logo-openbravo-112x45.png" width="112" height="45" alt="Openbravo" /></li>
-                        </ul>
-                        <p><a href="/partners/certified-software">View all certified software&nbsp;&rsaquo;</a></p>
-                    </div><!-- /.six-col -->
-                </div><!-- /.vertical-divider -->
-        </div><!-- /.box-padded-feature -->
-    </div><!-- /.twelve-col -->
+    <div class="twelve-col">
+        <h2 class="muted-heading">A selection of our software partners</h2>
+        <ul id="software-partners" class="inline-logos no-margin dynamic-logos"></ul>
+        <p class="align-center"><a href="/partners/certified-software">View all certified software&nbsp;&rsaquo;</a></p>
+    </div>
 </div><!-- /.row -->
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_server_download" second_item="_server_contact_us" third_item="_cloud_further_reading" %}
 
 {% endblock content %}
+
+
+{% block footer_extra %}
+{% load versioned_static  %}
+<script src="{% versioned_static 'js/partners.js' %}"></script>
+<script>
+partners.loadPartnerClouds([
+    {
+        'params': '?programme__name=Desktop&featured=true',
+        'elementId':'#hardware-partners'
+    },
+    {
+        'params': '?programme__name=OpenStack&service-offered=softwarecontent-publisher',
+        'elementId' : '#software-partners'
+    }
+]);
+</script>
+{% endblock footer_extra %}


### PR DESCRIPTION
## Done

* cleaned up the server css
* updated the /server/hyperscale to use the new logo clouds

## QA

1. go to /server/hyperscale and see that the logo clouds look ok
2. look at all /server/ pages and see that everything is the same as live

