### PR TITLE
Fixes secondary nav issue

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -493,10 +493,12 @@ body {
 }
 
 // extra rules for full width sections other than homepage
-.download,
-.phone,
+.cloud,
 .server,
-.tablet {
+.desktop,
+.phone,
+.tablet,
+.download {
   .row--dark {
       background: #262626;
       color: #ebebea;
@@ -515,9 +517,12 @@ body {
   }
 }
   // The default section row padding
+.cloud,
+.server,
+.desktop,
 .phone,
 .tablet,
-.server {
+.download {
   .row-hero {
     margin-top: 0;
 
@@ -550,9 +555,12 @@ body {
   }
 }
 
-.tablet,
+.cloud,
+.server,
+.desktop,
 .phone,
-.server {
+.tablet,
+.download {
   .row {
     padding: 20px 10px 0;
 


### PR DESCRIPTION
## Done

Add the new full width section classes to the 'extra rules for full width sections' SCSS

## QA

Pop on over to http://www.ubuntu.com-1610-dev.demo.haus/cloud and have a look at the ginormous  gap between the top of the secondary nav and the bottom of the man nav and then have a look locally. This fixes those problems

