### PR TITLE
removed columns from the .inline-small pattern

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -280,12 +280,13 @@ body {
   align-self: center;
 }
 // the small icons to the left of headings need to not be full width on small screens - this may well become a pattern
-.twelve-col .inline-small {
+.inline-small {
   float: left;
   margin-bottom: 10px;
   width: 48px;
   // this is to vertically center the heading/icon
   & + div > h3,
+  & + div > h2,
   & + h2 {
     float: left;
     margin-left: 1em;

--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -287,7 +287,10 @@ body {
   // this is to vertically center the heading/icon
   & + div > h3,
   & + h2 {
+    float: left;
+    margin-left: 1em;
     padding-top: 8px;
+    width: 66%;
   }
   @media only screen and (min-width: $breakpoint-medium) {
     margin-bottom: inherit;

--- a/templates/internet-of-things/developers.html
+++ b/templates/internet-of-things/developers.html
@@ -96,10 +96,12 @@
     <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="140" alt="" />
   </div>
   <div class="eight-col last-col">
-    <div class="inline-small one-col align-center for-small">
+    <div class="inline-small align-center for-small">
       <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="38" alt="" />
     </div>
-    <h2>Kick-start your next project</h2>
+    <div class="no-margin-bottom">
+        <h2>Kick-start your next project</h2>
+    </div>
     <p class="clear">If you&rsquo;re launching a crowdfunding project using snappy technology, talk to us first &mdash; and benefit from all the  support Canonical can provide.</p>
     <p><a href="/internet-of-things/contact-us" class="button--primary">Get in touch</a></p>
   </div>

--- a/templates/internet-of-things/features.html
+++ b/templates/internet-of-things/features.html
@@ -29,28 +29,28 @@
   </div>
   <ul class="no-bullets twelve-col equal-height--vertical-divider">
     <li class="equal-height--vertical-divider__item four-col">
-      <div class="inline-small one-col align-center">
+      <div class="inline-small align-center">
         <img src="{{ ASSET_SERVER_URL }}eb4f6183-picto-safety-orange.svg" width="50" alt="" />
       </div>
-      <div class="three-col last-col no-margin-bottom">
+      <div class="no-margin-bottom">
         <h3>Security built-in</h3>
       </div>
       <p class="clear">Critical infrastructure systems are common subjects for attacks, which is why all Ubuntu Core devices can be updated fast. And to ensure that apps can be installed safely, they are isolated using kernel containers, with human-friendly security profiles.</p>
     </li>
     <li class="equal-height--vertical-divider__item four-col">
-      <div class="inline-small one-col align-center">
+      <div class="inline-small align-center">
         <img src="{{ ASSET_SERVER_URL }}423e9265-picto-upgrade-orange.svg" width="50" alt="" />
       </div>
-      <div class="three-col last-col no-margin-bottom">
+      <div class="no-margin-bottom">
         <h3>Transactional updates</h3>
       </div>
       <p class="clear">Snappy lets you update your servers faster. All data is backed up allowing for rollback if it fails &mdash; so your system is never in an incomplete state. It means you can deploy updates automatically, protecting your valuable data and apps.</p>
     </li>
     <li class="equal-height--vertical-divider__item four-col last-col">
-      <div class="inline-small one-col align-center">
+      <div class="inline-small align-center">
         <img src="{{ ASSET_SERVER_URL }}c8cb5889-picto-edit-orange.svg" width="50" alt="" />
       </div>
-      <div class="three-col last-col no-margin-bottom">
+      <div class="no-margin-bottom">
         <h3>Signature authentication</h3>
       </div>
       <p class="clear">As well as isolating apps from each other (and the system itself), Ubuntu Core uses signatures to authenticate all code running on your servers and devices. If it&rsquo;s not the code you publish, it won&rsquo;t make it onto your devices. </p>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -87,10 +87,12 @@
     <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="140" alt="" />
   </div>
   <div class="eight-col last-col">
-    <div class="inline-small one-col align-center for-small">
+    <div class="inline-small align-center for-small">
       <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="38" alt="" />
     </div>
-    <h2>Let&rsquo;s work together</h2>
+    <div class="no-margin-bottom">
+        <h2>Let&rsquo;s work together</h2>
+    </div>
     <p class="clear">Want to talk to us about using Ubuntu Core for your next project?</p>
     <p><a href="/internet-of-things/contact-us" class="button--primary">Get in touch</a></p>
   </div>

--- a/templates/internet-of-things/partners.html
+++ b/templates/internet-of-things/partners.html
@@ -105,28 +105,28 @@
   </div>
   <div class="twelve-col equal-height--vertical-divider">
     <div class="equal-height--vertical-divider__item four-col">
-      <div class="inline-small one-col align-center">
+      <div class="inline-small align-center">
         <img src="{{ ASSET_SERVER_URL }}60d9b81e-picto-canonical.svg" width="50" alt="" />
       </div>
-      <div class="three-col last-col no-margin-bottom">
+      <div class="no-margin-bottom">
         <h3>Supported by Canonical</h3>
       </div>
       <p class="clear">Ubuntu Core is a free and open source operating system. There are no royalties associated with its usage. Commercial services can be provided by Canonical, however, for a per-unit service fee plus additional costs covering engineering, board certification, maintenance, quality assurance and third-party licensing.</p>
     </div>
     <div class="equal-height--vertical-divider__item four-col">
-      <div class="inline-small one-col align-center">
+      <div class="inline-small align-center">
         <img src="{{ ASSET_SERVER_URL }}c74f59b7-picto-reducecosts-warmgrey.svg" width="50" alt="" />
       </div>
-      <div class="three-col last-col no-margin-bottom">
+      <div class="no-margin-bottom">
         <h3>A complete solution</h3>
       </div>
       <p class="clear">Engagements cover component and system enablement as well as certification. Engagements are structured with baseline volume commitments, volume-based pricing for service fees and minimal recurrent engineering. Ubuntu Desktop is a complete solution for OEMs and ODMs.</p>
     </div>
     <div class="equal-height--vertical-divider__item four-col last-col">
-      <div class="inline-small one-col align-center">
+      <div class="inline-small align-center">
         <img src="{{ ASSET_SERVER_URL }}9816a979-picto-support-darkaubergine.svg" width="50" alt="" />
       </div>
-      <div class="three-col last-col no-margin-bottom">
+      <div class="no-margin-bottom">
         <h3>Ongoing support</h3>
       </div>
       <p class="clear">The ability to update your devices is central to your security and long-term competitiveness. Canonical takes care of all security and critical bug fixes to the base platform offering and provides the infrastructure to support your update management strategy. Ubuntu has a world-class track record maintaining a secure and stable operating system.</p>

--- a/templates/tablet/developers.html
+++ b/templates/tablet/developers.html
@@ -63,10 +63,10 @@
     <div class="twelve-col equal-height--vertical-divider">
       <div class="four-col equal-height--vertical-divider__item">
         <div class="four-col clearfix no-margin-bottom">
-          <div class="inline-small one-col align-center">
+          <div class="inline-small align-center">
             <img width="50" alt="A selection of apps" src="{{ ASSET_SERVER_URL }}c5022a72-browser-tabs.svg">
           </div>
-          <div class="three-col last-col no-margin-bottom">
+          <div class="no-margin-bottom">
             <h3>Convergent native apps</h3>
           </div>
         </div>
@@ -74,10 +74,10 @@
       </div>
       <div class="four-col equal-height--vertical-divider__item">
         <div class="four-col clearfix no-margin-bottom">
-          <div class="inline-small one-col align-center">
+          <div class="inline-small align-center">
             <img width="50" alt="" src="{{ ASSET_SERVER_URL }}5b24f6af-terminal-app-symbolic.svg">
           </div>
-          <div class="three-col last-col no-margin-bottom">
+          <div class="no-margin-bottom">
             <h3>HTML5 web apps</h3>
           </div>
         </div>
@@ -85,10 +85,10 @@
       </div>
       <div class="four-col equal-height--vertical-divider__item last-col">
         <div class="four-col clearfix no-margin-bottom">
-          <div class="inline-small one-col align-center">
+          <div class="inline-small align-center">
             <img width="50" alt="" src="{{ ASSET_SERVER_URL }}4ed8f862-search.svg">
           </div>
-          <div class="three-col last-col no-margin-bottom">
+          <div class="no-margin-bottom">
             <h3>Ubuntu&rsquo;s unique scopes</h3>
           </div>
         </div>


### PR DESCRIPTION
## Done

* removed the columns between the icon and heading in the inline-small pattern as this will never work on mobile as side by side

## QA

1. go to /internet-of-things/features and see that the 'Setting the security standard' section looks good in all screen sizes
2. go to /internet-of-things/partners and see that the 'Commercial information' section looks good in all screen sizes
3. go to /tablet/developers and see that the 'A selection of apps' section looks good in all screen sizes
4. go to /internet-of-things/developers and see that the 'Kick-start your next project' section looks good in all screen sizes
5. go to /internet-of-things and see that the 'Let's work together' section looks good in all screen sizes

## Issue / Card

Fixes #381 and #358

## Screenshots

small

![image](https://cloud.githubusercontent.com/assets/441217/18788086/6e3eee3a-819d-11e6-8b31-b05bcd375b05.png)

medium

![image](https://cloud.githubusercontent.com/assets/441217/18788111/8d2eb71c-819d-11e6-8e37-d8cfff9428b7.png)

large

![image](https://cloud.githubusercontent.com/assets/441217/18788099/7fbee890-819d-11e6-9733-ccb4cb34bff6.png)
