### PR TITLE
Add mobile retina image to Kubernetes takeover

### DIFF
--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -1690,15 +1690,15 @@ body.homepage-kubernetes-takeover {
   #main-content {
     .row-hero {
       background-image: url('#{$asset-server}f5e7d881-Kubernetes_backgd_mobile.png');
-      
-      @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) { 
-        background-image: url('#{$asset-server}32d31c25-Kubernetes_backgd_mobile_720.png');
-      }
-      
       background-color: $light-grey;
       background-size: cover;
       background-repeat: no-repeat;
       margin-top: 0;
+      
+      @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) { 
+        background-image: url('#{$asset-server}32d31c25-Kubernetes_backgd_mobile_720.png');
+        background-size: 100%;
+      }
       
       @media only screen and (min-width : $breakpoint-medium) {
         background-image: url('#{$asset-server}c0df5df2-Kubernetes_backgd_desktop-1.png');

--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -1697,6 +1697,7 @@ body.homepage-kubernetes-takeover {
       
       @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) { 
         background-image: url('#{$asset-server}32d31c25-Kubernetes_backgd_mobile_720.png');
+        background-position: right 40px;
         background-size: 100%;
       }
       

--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -1690,6 +1690,11 @@ body.homepage-kubernetes-takeover {
   #main-content {
     .row-hero {
       background-image: url('#{$asset-server}f5e7d881-Kubernetes_backgd_mobile.png');
+      
+      @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) { 
+        background-image: url('#{$asset-server}32d31c25-Kubernetes_backgd_mobile_720.png');
+      }
+      
       background-color: $light-grey;
       background-size: cover;
       background-repeat: no-repeat;


### PR DESCRIPTION
## Done

Add mobile retina image to Kubernetes takeover

## QA

if you have a retina type mobile device pop on over to http://www.ubuntu.com-kubernetes-takeover.demo.haus/ and have a look at the takeover background, then go to ubuntu.com and compare the two, you’ll find that the former is so crisp in comparison


