### PR TITLE
removed chevron from button

### DIFF
--- a/templates/cloud/kubernetes.html
+++ b/templates/cloud/kubernetes.html
@@ -80,7 +80,7 @@
             <p>We also offer consulting services and customisation for larger organisations to integrate Kubernetes with existing infrastructure.</p>
             <p>For customers needing a fully managed Kubernetes, Canonical will deploy and operate your cluster remotely, and hand over to your own team as soon as they are familiar with the operational practices under the hood.</p>
             <p>To discuss your requirement connect with a member of the Canonical team.</p>
-            <p><a href="/cloud/contact-us" class="button--primary">Contact us&nbsp;&rsaquo;</a></p>
+            <p><a href="/cloud/contact-us" class="button--primary">Contact us</a></p>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done

Removed a chevron from a button on the kubernetes page
## QA

See that the "contact us" button on `/cloud/kubernetes/` no longer has an angle quote chevron.
