### PR TITLE
add link to PDF

### DIFF
--- a/templates/cloud/kubernetes.html
+++ b/templates/cloud/kubernetes.html
@@ -63,7 +63,7 @@
             <li>Elastic Stack for Insights with Beats log collection and monitoring and analysis and visualisation with Elasticsearch and Kibana</li>
             <li>Optionally backed by Ceph for filesystem and block storage</li>
         </ul>
-        <p><a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Datasheet_Canonical-kubernetes_28.09.16_WEB.pdf">Learn more in the Canonical Distribution of Kubernetes&nbsp;datasheet&nbsp;&rsaquo;</a></p>
+        <p><a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Datasheet_Canonical-kubernetes_28.09.16_WEB.pdf" class="external">Learn more in the Canonical Distribution of Kubernetes&nbsp;datasheet</a></p>
     </div>
     <div class="six-col last-col">
         <div class="juju-card" data-id="canonical-kubernetes"></div>

--- a/templates/cloud/kubernetes.html
+++ b/templates/cloud/kubernetes.html
@@ -63,6 +63,7 @@
             <li>Elastic Stack for Insights with Beats log collection and monitoring and analysis and visualisation with Elasticsearch and Kibana</li>
             <li>Optionally backed by Ceph for filesystem and block storage</li>
         </ul>
+        <p><a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Datasheet_Canonical-kubernetes_28.09.16_WEB.pdf">Learn more in the Canonical Distribution of Kubernetes&nbsp;datasheet&nbsp;&rsaquo;</a></p>
     </div>
     <div class="six-col last-col">
         <div class="juju-card" data-id="canonical-kubernetes"></div>


### PR DESCRIPTION
## Done

Added a link to the PDF datasheet on the Kubernetes page

## QA

Go to `/cloud/kubernetes/` and see the new link at the bottom of the "Production features" list.

