### PR TITLE
update support portal link

### DIFF
--- a/templates/shared/_ubuntu_advantage_whats_included.html
+++ b/templates/shared/_ubuntu_advantage_whats_included.html
@@ -35,8 +35,8 @@
         <div class="four-col last-col no-margin-bottom equal-height__item">
             <h3>Customer login</h3>
             <p>Already a customer? Access the support portal or Landscape&#39;s SaaS.</p>
-            <p><a href="https://login.ubuntu.com/+saml/init/salesforce/500/o">Support portal login&nbsp;&rsaquo;</a></p>
-            <p><a href="https://landscape.canonical.com/">Landscape login&nbsp;&rsaquo;</a></p>
+            <p><a href="https://support.canonical.com/" class="external">Support portal login</a></p>
+            <p><a href="https://landscape.canonical.com/login/authenticate" class="external">Landscape login</a></p>
         </div><!-- /.four-col -->
     </div><!-- /.twelve-col -->
     <p><a href="https://buy.ubuntu.com" class="button--primary"><span class="external">Buy Ubuntu Advantage</span></a></p>


### PR DESCRIPTION
## Done

* updated support portal link and landscape link on /management/ubuntu-advantage
* updated the [copy doc](https://docs.google.com/document/d/1zT7brp0Jqr5CLnp1CIODOZ6ruohoGbTRB0giEyiRmSo/edit#)

## QA

1. go to /management/ubuntu-advantage and see tha tthe support portal link goes to https://support.canonical.com
2. see that the landscape link goes to https://landscape.canonical.com/login/authenticate

## Issue / Card

Fixes #903

