### PR TITLE
Fix clicks on "Multiple devices, one experience" row

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -68,7 +68,6 @@ core.setupAnimations = function() {
             });
 
             sliderAnimation.addEventListener('click', function(e) {
-                e.preventDefault();
                 sliderAnimation.classList.add('run');
                 setTimeout(function(e) {
                     sliderAnimation.classList.remove('run');


### PR DESCRIPTION
No need to preventDefault for this one. It's breaking links!

This fixes #910

QA
---

Visit homepage, check clicking "Multiple devices one experience" goes to phone page. Check the row otherwise continues to behave as expected - clicking restarts the animation.