### PR TITLE
Move Insights feed to backend

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -298,32 +298,21 @@
 <section class="row row-insights row-grey no-padding-bottom">
     <h2 class="twelve-col">The latest Ubuntu Cloud news and events</h2>
     <div class="twelve-col equal-height--vertical-divider no-margin-bottom">
-      <div id="insights-cloud-feed" class='six-col equal-height--vertical-divider__item'>
-        <ul class="no-bullets">
-          <li>Read news, case studies, whitepapers and more on <a class="external" href="https://insights.ubuntu.com">insights.ubuntu.com</a></li>
-        </ul>
-      </div><!-- end .insights-cloud-feed -->
-      <script>
-        $(function() {
-          $.getFeed({
-            url: 'https://insights.ubuntu.com/topic/Cloud/feed',
-            success: function(feed) {
-              var html = "";
-              for(var i = 0; i < feed.items.length && i < 4; i++) {
-                var item = feed.items[i];
-                var d = $.trim(item.description).substring(0, 100).split(" ").slice(0, -1).join(" ") + "\&hellip\;";
-                html += "<li class='six-col'><h3 class='newsevent__title'><a href='" + item.link + "' class='external'>" + item.title + "</a></h3><p>" + d + "</p></li>";
-              }
-              html = "<div id='insights-cloud-feed' class='equal-height--vertical-divider__item six-col'><ul class='no-bullets'>" + html + "</ul></div>";
-              if ($('#insights-cloud-feed')) {
-                $('#insights-cloud-feed').replaceWith(html);
-              }
-            }
-          });
-        });
-      </script>
+        <div id='insights-cloud-feed' class='equal-height--vertical-divider__item six-col'>
+            <ul class='no-bullets'>
+                {% get_rss_feed "https://insights.ubuntu.com/topic/Cloud/feed/" limit=4 as cloud_feed %}
+                {% autoescape off %}
+                {% for item in cloud_feed %}
+                <li class='six-col'>
+                    <h3 class='newsevent__title'><a href='{{ item.link }}' class='external'>{{ item.title }}</a></h3>
+                    <p>{{ item.description|force_escape|truncate_chars:100 }}</p>
+                </li>
+                {% endfor %}
+                {% endautoescape %}
+            </ul>
+        </div>
 {% include "cloud/shared/_events_overview.html" %}
-    </div><!-- end .twelve-col .vertical-divider -->
+    </div>
 </section>
 
 <section class="row no-border">

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -326,7 +326,6 @@
 
 {% block head_extra %}
 <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
-<script src="{{ ASSET_SERVER_URL }}c954db4a-jfeed_prm.js"></script>
 
 <style type="text/css">
   @keyframes fadeIn {

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,6 @@
 
 {% block head_extra %}
 <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
-<script src="{{ ASSET_SERVER_URL }}c954db4a-jfeed_prm.js"></script>
 {% endblock %}
 
 {% block takeover_content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,5 @@
 {% extends "base_index.html" %}
 
-
 {% block takeover_body_class %}homepage-kubernetes-takeover{% endblock takeover_body_class %}
 
 {% block head_extra %}
@@ -12,34 +11,21 @@
 
 {% include "takeovers/_kubernetes_takeover.html" %}
 
-<section class="row row--ubuntu-news js-hidden strip no-border">
+<section class="row row--ubuntu-news strip no-border">
     <div class="strip-inner-wrapper">
         <div class="twelve-col">
             <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/">Latest news from Insights</a></span></h2>
-            <div id="insights-cloud-feed" class="twelve-col"></div>
-            <script type="text/javascript">
-              $(function() {
-                $.getFeed({
-                  url: 'https://insights.ubuntu.com/feed',
-                  success: function(feed) {
-                    var html = "<ul class='row--ubuntu-news__list no-bullets vertical-divider'>";
-                    for (var i = 0; i < feed.items.length && i < 4; i++) {
-                      var item = feed.items[i];
-                      var lastClass = "";
-                      if (i != 0 && i % 3 == 0) {
-                        lastClass = ' last-col';
-                      }
-                      html += "<li class='three-col" + lastClass + "'><h3><a href='" + item.link + "'>" + item.title + "</a></h3><p><time pubdate datetime='" + item.updated + "'>" + item.nicedate + "</time></p></li>";
-                    }
-                    html += "</ul>";
-                    if ($('#insights-cloud-feed')) {
-                      $('#insights-cloud-feed').append(html);
-                      $('.row--ubuntu-news').removeClass('js-hidden');
-                    }
-                  }
-                });
-              });
-            </script>
+            <div id="insights-cloud-feed" class="twelve-col">
+                <ul class="row--ubuntu-news__list no-bullets vertical-divider">
+                    {% get_rss_feed "https://insights.ubuntu.com/feed/" limit=4 as cloud_feed %}
+                    {% for item in cloud_feed %}
+                    <li class="three-col {% if forloop.last %}last-col{% endif %}">
+                        <h3><a href="{{ item.link }}">{{ item.title }}</a></h3>
+                        <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
         </div>
     </div>
 </section>

--- a/templates/templates/_further_reading_links.html
+++ b/templates/templates/_further_reading_links.html
@@ -1,29 +1,7 @@
-{% block head_extra %}
-<script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
-<script src="{{ ASSET_SERVER_URL }}c954db4a-jfeed_prm.js"></script>
-{% endblock %}
-	<div id="insights-footer-feed"><noscript><a class="external" href="https://insights.ubuntu.com" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'insights.u.c no js message', 'eventLabel' : 'Further reading', 'eventValue' : undefined });">Find out more at insights.ubuntu.com</a></noscript></div>
-	<script>
-		var feedurl={% if feed %}"{{ feed }}"{% else %}"https://insights.ubuntu.com/feed/"{% endif %};
-		var feedlimit={% if articles %}{{ articles }}{% else %}4{% endif %};
-    $.getFeed({
-      url: feedurl,
-      success: function(feed) {
-        var html = "<ul class='contextual-footer__list'>";
-        for(var i = 0; i < feed.items.length && i < feedlimit; i++) {
-          var item = feed.items[i];
-          html += "<li><a href='" + item.link + "'>" + item.title + "&nbsp;&rsaquo;</a></li>";
-        }
-        html += "</ul>";
-        if ($('#insights-footer-feed')) {
-          $('#insights-footer-feed').append(html);
-        }
-      }, failure: function () {
-        var html = "<ul class='contextual-footer__list'><li>Read news, case studies, whitepapers and more on <a class='external' href='https://insights.ubuntu.com'>insights.ubuntu.com</a></li></ul>"; // default if feed fails
-        if ($('#insights-footer-feed')) {
-          $('#insights-footer-feed').append(html);
-        }
-      }
-    });
+{% get_rss_feed "https://insights.ubuntu.com/feed/" limit=4 as feed %}
 
-</script>
+<ul class='contextual-footer__list'>
+{% for item in feed %}
+    <li><a href="{{item.link}}">{{item.title}}&nbsp;&rsaquo;</a></li>
+{% endfor %}
+</ul>

--- a/webapp/lib/feeds.py
+++ b/webapp/lib/feeds.py
@@ -1,8 +1,10 @@
 import feedparser
 import logging
 import json
+from datetime import datetime
 from requests.exceptions import Timeout
 from requests_cache import CachedSession
+from time import mktime
 
 from django.conf import settings
 
@@ -57,4 +59,9 @@ def get_rss_feed_content(url, offset=0, limit=None):
         )
         content = []  # Empty response
 
-    return content[offset:end]
+    content = content[offset:end]
+    for item in content:
+        updated_time = mktime(item['updated_parsed'])
+        item['updated_datetime'] = datetime.fromtimestamp(updated_time)
+
+    return content

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -53,6 +53,7 @@ TEMPLATES = [
         'OPTIONS': {
             'builtins': [
                 'webapp.templatetags.feeds',
+                'webapp.templatetags.utils',
             ],
             'context_processors': [
                 'django_asset_server_url.asset_server_url',

--- a/webapp/templatetags/utils.py
+++ b/webapp/templatetags/utils.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def truncate_chars(value, max_length):
+    length = len(value)
+    if length > max_length:
+        truncated = value[:max_length]
+        if not length == (max_length + 1) and value[max_length + 1] != " ":
+            truncated = truncated[:truncated.rfind(" ")]
+        return truncated + "&hellip;"
+    return value


### PR DESCRIPTION
## Done

Move javascript feed parsing to backend template logic.

## QA

Check feeds on:
- `/`
- `/cloud`
- `/management`

They should not look any different, and should not pop in! Yay!
In between refreshes, they should be cached.
