### PR TITLE
Minimise redirects by removing slashes

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -12,7 +12,7 @@
     <div class="six-col">
         <h1>Ubuntu Desktop for&nbsp;developers</h1>
         <p>Whether you&rsquo;re a mobile app developer, an engineering manager, a music or video editor or a financial analyst with large-scale models to run &mdash; in fact, anyone in need of a powerful machine for your work &mdash; Ubuntu is the ideal platform.</p>
-        <p><a href="/download/desktop/" class="button--primary">Get Ubuntu now</a></p>
+        <p><a href="/download/desktop" class="button--primary">Get Ubuntu now</a></p>
         {% include "desktop/shared/_share-this.html" with tweet="Check out #Ubuntu, the developers&rsquo; favourite desktop OS" %}
     </div>
 </div>
@@ -131,7 +131,7 @@
         <div>
             <h3>Support tailored to developers&rsquo; needs</h3>
             <p>With Ubuntu Advantage and Landscape, you can standardise your developer workstations. It helps you manage updates, security patches, and reporting, while minimising downtime. Give your developers the freedom they want while retaining the control you need.</p>
-            <p><a href="/management/">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+            <p><a href="/management">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
         </div>
     </div>
     <div class="pull-right right">

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -76,7 +76,7 @@
         <div>
             <h2>Pre-installed on certified&nbsp;hardware</h2>
             <p>Ubuntu runs on the world&rsquo;s best hardware from partners such as Dell, HP and Lenovo. And with nearly 90% of PCs shipped by the major PC companies already certified to work with Ubuntu, it is easy to find hardware that will work for your business.</p>
-            <p><a href="/certification/">Learn more about Ubuntu certified hardware&nbsp;&rsaquo;</a></p>
+            <p><a href="/certification">Learn more about Ubuntu certified hardware&nbsp;&rsaquo;</a></p>
         </div>
     </div>
 </div>

--- a/templates/download/desktop/contribute.html
+++ b/templates/download/desktop/contribute.html
@@ -19,7 +19,7 @@
             <noscript>
                 <p><strong>Contributions require JavaScript. Please enable JavaScript if you want to contribute.</strong></p>
                 {% if start_download %}
-                <p><a href="/download/desktop/thank-you/?version={{ version }}&amp;architecture={{ architecture }}">Take me to the download&nbsp;&rsaquo;</a></p>
+                <p><a href="/download/desktop/thank-you?version={{ version }}&amp;architecture={{ architecture }}">Take me to the download&nbsp;&rsaquo;</a></p>
                 {% endif %}
             </noscript>
         </div>
@@ -115,14 +115,14 @@
                 <input type="hidden" name="no_shipping" value="1">
                 <input type="hidden" name="rm" value="1">
 
-                <input type="hidden" name="return" value="http://{{ http_host }}/download/desktop/thank-you/?version={{ version }}&amp;architecture={{ architecture }}">
-                <input type="hidden" name="cancel_return" value="http://{{ http_host }}/download/desktop/thank-you/?version={{ version }}&amp;architecture={{ architecture }}">
+                <input type="hidden" name="return" value="http://{{ http_host }}/download/desktop/thank-you?version={{ version }}&amp;architecture={{ architecture }}">
+                <input type="hidden" name="cancel_return" value="http://{{ http_host }}/download/desktop/thank-you?version={{ version }}&amp;architecture={{ architecture }}">
 
                 <input type="hidden" name="bn" value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHosted">
                 <button type="submit" class="contribute__submit" tabindex="9">Pay with PayPal</button>
 
                 {% if start_download %}
-                <a href="/download/desktop/thank-you/?version={{ version }}&amp;architecture={{ architecture }}" class="contribute__skip" tabindex="11">Not now, take me to the download&nbsp;&rsaquo;</a>
+                <a href="/download/desktop/thank-you?version={{ version }}&amp;architecture={{ architecture }}" class="contribute__skip" tabindex="11">Not now, take me to the download&nbsp;&rsaquo;</a>
                 {% endif %}
             </div>
         </form>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -39,7 +39,7 @@
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
                     <p>
-                        <a class="button--primary link-cta-download" href="/download/desktop/thank-you/?version={{lts_release}}&amp;architecture=amd64">Download</a>
+                        <a class="button--primary link-cta-download" href="/download/desktop/thank-you?version={{lts_release}}&amp;architecture=amd64">Download</a>
                         <script>
                             // Contributions only work with JavaScript
                             // So if we have JavaScript, send them to /contribute

--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -38,7 +38,7 @@
 		</table>
 	</div>
 	<div class="six-col">
-		<p><a href="/download/">Download the latest version of Ubuntu&nbsp;&rsaquo;</a></p>
+		<p><a href="/download">Download the latest version of Ubuntu&nbsp;&rsaquo;</a></p>
 	</div>
 </div>
 

--- a/templates/legal/short-terms/2015-09-09.html
+++ b/templates/legal/short-terms/2015-09-09.html
@@ -140,7 +140,7 @@
     <div class="box four-col last-col">
         <h3>Latest version</h3>
         <ul class="list">
-            <li class="last-item"><a href="/legal/short-terms/">Latest version&nbsp;›</a></li>
+            <li class="last-item"><a href="/legal/short-terms">Latest version&nbsp;›</a></li>
         </ul>
     </div>
 </div>

--- a/templates/legal/short-terms/2016-05-20.html
+++ b/templates/legal/short-terms/2016-05-20.html
@@ -140,7 +140,7 @@
     <div class="box four-col last-col">
         <h3>Latest version</h3>
         <ul class="list">
-            <li class="last-item"><a href="/legal/short-terms/">Latest version&nbsp;›</a></li>
+            <li class="last-item"><a href="/legal/short-terms">Latest version&nbsp;›</a></li>
         </ul>
     </div>
 

--- a/templates/legal/terms-and-policies/intellectual-property-policy/2013-05-14/index.html
+++ b/templates/legal/terms-and-policies/intellectual-property-policy/2013-05-14/index.html
@@ -29,7 +29,7 @@
 
 	<div class="four-col box last-col">
 		<h3>Latest version</h3>
-		<p>This is a previous version of this document, please refer to the <a href="/legal/terms-and-policies/intellectual-property-policy/">latest version</a>.</p>
+		<p>This is a previous version of this document, please refer to the <a href="/legal/terms-and-policies/intellectual-property-policy">latest version</a>.</p>
 	</div>
 	<div class="four-col box last-col">
 		<h3>Registered office</h3>

--- a/templates/legal/terms-and-policies/privacy-policy/2013-03-25/index.html
+++ b/templates/legal/terms-and-policies/privacy-policy/2013-03-25/index.html
@@ -25,7 +25,7 @@
   </div><!-- end .eight-col -->
   <div class="four-col box last-col">
     <h3>Latest version</h3>
-    <p>This is a previous version of this document, please refer to the <a href="/legal/terms-and-policies/privacy-policy/">latest version</a>.</p>
+    <p>This is a previous version of this document, please refer to the <a href="/legal/terms-and-policies/privacy-policy">latest version</a>.</p>
   </div><!-- end .four-col -->
 </div><!-- end .row-col -->
 

--- a/templates/templates/_nav_breadcrumb.html
+++ b/templates/templates/_nav_breadcrumb.html
@@ -1,20 +1,20 @@
 <ul class="breadcrumb">
 	{% if level_2 and not level_3 and not tertiary %}
-		<li><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
+		<li><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="breadcrumb-link" href="/{{ level_1 }}">{{ section_title }}</a>
 	{% else %}
 		{% if level_3 %}
-			<li><a class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
+			<li><a class="breadcrumb-link" href="/{{ level_1 }}">{{ section_title }}</a>
 			<ul class="second-level-nav">
-				<li><a class="breadcrumb-link--second-level" href="/{{ level_1 }}/{{ level_2 }}/">{{ subsection_title }}</a></li>
+				<li><a class="breadcrumb-link--second-level" href="/{{ level_1 }}/{{ level_2 }}">{{ subsection_title }}</a></li>
 			</ul>
 		{% else %}
 			{% if level_2 %}
-				<li><a class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
+				<li><a class="breadcrumb-link" href="/{{ level_1 }}">{{ section_title }}</a>
 				<ul class="second-level-nav">
-					<li><a class="active breadcrumb-link--second-level" href="/{{ level_1 }}/{{ level_2 }}/">{{ page_title }}</a></li>
+					<li><a class="active breadcrumb-link--second-level" href="/{{ level_1 }}/{{ level_2 }}">{{ page_title }}</a></li>
 				</ul>
 			{% else %}
-				<li><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
+				<li><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="breadcrumb-link" href="/{{ level_1 }}">{{ section_title }}</a>
 			{% endif %}
 		{% endif %}
 	{% endif %}

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -8,25 +8,25 @@
         <div class="footer-a">
             <div class="clearfix">
                 <ul>
-                    <li class="secondary secondary-cloud"><h2><a href="/cloud/">Cloud</a></h2>
+                    <li class="secondary secondary-cloud"><h2><a href="/cloud">Cloud</a></h2>
                         {% include "cloud/_nav_secondary.html" %}
                     </li>
-                    <li class="secondary secondary-server"><h2><a href="/server/">Server</a></h2>
+                    <li class="secondary secondary-server"><h2><a href="/server">Server</a></h2>
                         {% include "server/_nav_secondary.html" %}
                     </li>
-                    <li class="secondary secondary-desktop"><h2><a href="/desktop/" class="active-trail">Desktop</a></h2>
+                    <li class="secondary secondary-desktop"><h2><a href="/desktop" class="active-trail">Desktop</a></h2>
                         {% include "desktop/_nav_secondary.html" %}
                     </li>
-                    <li class="secondary secondary-phone"><h2><a href="/phone/">Phone</a></h2>
+                    <li class="secondary secondary-phone"><h2><a href="/phone">Phone</a></h2>
                         {% include "phone/_nav_secondary.html" with location="footer" %}
                     </li>
-                    <li class="secondary secondary-tablet"><h2><a href="/tablet/">Tablet</a></h2>
+                    <li class="secondary secondary-tablet"><h2><a href="/tablet">Tablet</a></h2>
                         {% include "tablet/_nav_secondary.html" with location="footer" %}
                     </li>
-                    <li class="secondary secondary-tv"><h2><a id="IoT-footer" href="/internet-of-things/">IoT</a></h2>
+                    <li class="secondary secondary-tv"><h2><a id="IoT-footer" href="/internet-of-things">IoT</a></h2>
                         {% include "internet-of-things/_nav_secondary.html" %}
                     </li>
-                    <li class="secondary secondary-management"><h2><a href="/management/">Management</a></h2>
+                    <li class="secondary secondary-management"><h2><a href="/management">Management</a></h2>
                         {% include "management/_nav_secondary.html" %}
                     </li>
                 </ul>
@@ -34,13 +34,13 @@
         </div><!-- /.footer-a -->
         <div class="footer-b inline-lists">
             <ul class="clearfix">
-                <li><h2><a href="/download/">Download</a></h2>
+                <li><h2><a href="/download">Download</a></h2>
                     {% include "download/_nav_secondary.html" %}
                 </li>
-                <li><h2><a href="/support/">Support</a></h2>
+                <li><h2><a href="/support">Support</a></h2>
                     {% include "support/_nav_secondary.html" %}
                 </li>
-                <li><h2><a href="/about/">About</a></h2>
+                <li><h2><a href="/about">About</a></h2>
                     <ul class="second-level-nav">
                         <li><a href="/about/about-ubuntu">About Ubuntu</a></li>
                         <li><a href="http://www.canonical.com/careers">Careers</a></li>


### PR DESCRIPTION
Any URLs ending in "/" will redirect to without the "/".

With HTTPS this will be exacerbated, because the TemplateFinder will redirect from https://xxxx/ to http://xxxx, which will then be redirected back to https://xxxx.

So removing any internal links with "/" on the end will reduce unnecessary redirects.

I used [a simple ack command](https://gist.github.com/nottrobin/28f8570add88222727b85a55e7f02c90) to find these links, then I removed them.