### PR TITLE
Strip HTML when using *release_full in page title

### DIFF
--- a/templates/download/desktop/install-ubuntu-desktop.html
+++ b/templates/download/desktop/install-ubuntu-desktop.html
@@ -1,6 +1,6 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Install Ubuntu {{lts_release_full}}{% endblock %}
+{% block title %}Install Ubuntu {{lts_release_full|striptags}}{% endblock %}
 
 {% block extra_body_class %}download-help{% endblock %}
 


### PR DESCRIPTION
## Done

Removed HTML from page title by stripping tags with Django

## QA

- Navigate to `/download/desktop/install-ubuntu-desktop`
- Check that browser page title does not include HTML. It should read `Install Ubuntu 16.04 LTS | Ubuntu`

## Issue / Card

Fixes #925 


