### PR TITLE
remove row-grey from insights news on the homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
 
 {% include "takeovers/_kubernetes_takeover.html" %}
 
-<section class="row row--ubuntu-news js-hidden row-grey strip no-border">
+<section class="row row--ubuntu-news js-hidden strip no-border">
     <div class="strip-inner-wrapper">
         <div class="twelve-col">
             <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/">Latest news from Insights</a></span></h2>


### PR DESCRIPTION
## Done

* make the insights news row under the takeover have a white background (by removing row-grey, the existing row class is white already)

## QA

1. go to the homepage
2. see that the news is on a white background

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/19194822/f19d58a2-8ca6-11e6-93fa-75e8d93a69af.png)
