### PR TITLE
add row-hero to kubernetes page

### DIFF
--- a/templates/cloud/kubernetes.html
+++ b/templates/cloud/kubernetes.html
@@ -10,7 +10,7 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row">
+<section class="row row-hero">
     <div class="equal-height">
         <div class="eight-col equal-height__item">
             <h1>The Canonical Distribution of&nbsp;Kubernetes</h1>


### PR DESCRIPTION
## Done

* added the missing class 'row-hero' to the row
* Yaili design +1ed, told Graham for 
## QA

1. go to /cloud/kubernetes and see the h1 is in the same place as other sections in /cloud

## Issue / Card

Fixes #927 