### PR TITLE
add a comma in /desktop/snappy instructions

### DIFF
--- a/templates/desktop/snappy.html
+++ b/templates/desktop/snappy.html
@@ -148,7 +148,7 @@
     <div class="wrapper">
       <div class="eight-col">
         <h2>How to use snaps from the command line</h2>
-        <p>If you are running Ubuntu 16.04 LTS or later, you can already use snaps from the command line. Otherwise do not despair we have instructions for <a class="external" href="http://snapcraft.io/docs/core/install">multiple distros</a>.</p>
+        <p>If you are running Ubuntu 16.04 LTS or later, you can already use snaps from the command line. Otherwise do not despair, we have instructions for <a class="external" href="http://snapcraft.io/docs/core/install">multiple distros</a>.</p>
         <p>To list all snaps installed on your machine:</p>
         <pre class="command-line code-block"><code>$ sudo snap list</code></pre>
         <p>To find a snap in the store:</p>


### PR DESCRIPTION
## Done

* added a comma

## QA

1. go to /desktop/snappy
2. see the 'How to use snaps from the command line' section has a comma before the 'we have instructions' text.

## Screenshots
![image](https://cloud.githubusercontent.com/assets/441217/19309641/25a978f8-907e-11e6-81b9-7dea0a4afc58.png)
