### PR TITLE
remove forms from download pages

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -56,10 +56,10 @@
         <div class="four-col">
             <h3 class="external--title"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
             <ul class="no-bullets list">
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_full_with_point}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_full_with_point}}-desktop-i386.iso.torrent">Ubuntu {{latest_release}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_full_with_point}}-server-amd64.iso.torrent">Ubuntu {{latest_release}} Server (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_full_with_point}}-server-i386.iso.torrent">Ubuntu {{latest_release}} Server (32-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-i386.iso.torrent">Ubuntu {{latest_release}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-amd64.iso.torrent">Ubuntu {{latest_release}} Server (64-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-i386.iso.torrent">Ubuntu {{latest_release}} Server (32-bit)&nbsp;&rsaquo;</a></li>
             </ul>
         </div><!-- /.four-col -->
         <div class="four-col last-col">

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -39,7 +39,7 @@
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
                     <p>
-                        <a class="button--primary link-cta-download" href="/download/desktop/thank-you?version={{lts_release}}&amp;architecture=amd64">Download</a>
+                        <a class="button--primary link-cta-download" href="/download/desktop/thank-you?version={{lts_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{lst_release_full}}', 'eventValue' : undefined });">Download</a>
                         <script>
                             // Contributions only work with JavaScript
                             // So if we have JavaScript, send them to /contribute
@@ -66,20 +66,11 @@
                     <p>The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{latest_release}} comes with nine months of security and maintenance updates.</p>
                     <p><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="external">Ubuntu {{latest_release}} release notes</a></p>
 
-                    <p>Recommended system requirements:</p>
-
-                    <ul class="list-ticks--compact">
-                        <li>2 GHz dual core processor or better</li>
-                        <li>2 GB system memory</li>
-                        <li>25 GB of free hard drive space</li>
-                        <li>Either a DVD drive or a USB port for the installer media</li>
-                        <li>Internet access is helpful</li>
-                    </ul>
-
+                    <p>Recommended system requirements are the same as for Ubuntu {{lts_release_full_with_point}}.</p>
                 </div>
-                <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom download-button">
+                <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
                     <p>
-                        <a class="button--primary link-cta-download" href="/download/desktop/thank-you/?version={{latest_release}}&amp;architecture=amd64">Download</a>
+                        <a class="button--primary link-cta-download" href="/download/desktop/thank-you/?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a>
                         <script>
                             // Contributions only work with JavaScript
                             // So if we have JavaScript, send them to /contribute
@@ -99,7 +90,6 @@
 
 <div class="row row-easy-ways">
     <div class="strip-inner-wrapper">
-
 
         <div class="twelve-col">
             <h2>Easy ways to switch to Ubuntu</h2>

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -24,7 +24,7 @@
                     <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release_full}} release notes</a></p>
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
-                    <p><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="link-cta-download button--primary">Download</a></p>
+                    <p><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{lst_release_full}}', 'eventValue' : undefined });">Download</a></p>
                     <p><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
                 </div><!-- /.four-col -->
             </div><!-- /.box -->
@@ -37,16 +37,8 @@
                     <p>The latest version of Ubuntu Server, including the Newton release of OpenStack and nine months of security and maintenance updates.</p>
                     <p><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{latest_release}} release notes</a></p>
                 </div>
-                <div class="four-col equal-height--vertical-divider__item last-col">
-                    <form class="form-download gap-from-top" action="/download/server/thank-you/" method="get">
-                        <fieldset>
-                            <input name="version" value="{{latest_release}}" type="hidden">
-                            <input name="architecture" value="amd64" type="hidden">
-                        </fieldset>
-                        <div>
-                            <button type="submit">Download</button>
-                        </div>
-                    </form>
+                <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
+                    <p><a href="/download/server/thank-you?version={{latest_release}}&amp;architecture=amd64" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a></p>
                     <p><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
                 </div><!-- /.four-col -->
             </div><!-- /.box -->

--- a/templates/download/ubuntu-kylin.html
+++ b/templates/download/ubuntu-kylin.html
@@ -27,15 +27,15 @@
                     href="http://cdimage.ubuntu.com/ubuntukylin/releases/{{lts_release}}/release/ubuntukylin-{{lts_release}}-desktop-amd64.iso"
                     class="link-cta-download button--primary"
                     onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : '{{lts_release}} 64 bit', 'eventLabel' : 'Ubuntu Kylin', 'eventValue' : undefined });
-                    ">Download 64-bit</a>
+                    ">Download (64-bit)</a>
                 </p>
 
                 <p>
                     <a
                     href="http://cdimage.ubuntu.com/ubuntukylin/releases/{{lts_release}}/release/ubuntukylin-{{lts_release}}-desktop-i386.iso"
                     class="link-cta-download button--primary"
-                    onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : '{{lts_release}} 32 bit', 'eventLabel' : 'Ubuntu Kylin', 'eventValue' : undefined });
-                    ">Download 32-bit</a>
+                    onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : '{{lts_release}} 32 bit', 'eventLabel' : 'Ubuntu Kylin', 'eventValue' : undefined });"
+                    >Download (32-bit)</a>
                 </p>
                 <p class="note">If you have an older PC with less than 2GB of memory, choose the 32-bit download.</p>
             </div>
@@ -50,28 +50,19 @@
             <div class="box box-highlight clearfix vertical-divider">
                 <div class="eight-col no-margin-bottom">
                     <h2>Ubuntu Kylin {{latest_release}}</h2>
-                    <p>Download the latest version, Ubuntu Kylin {{latest_release}} as an ISO image file. To install Ubuntu Kylin, burn the image file onto a DVD or create a bootable USB disk.
-</p>
+                    <p>Download the latest version, Ubuntu Kylin {{latest_release}} as an ISO image file. To install Ubuntu Kylin, burn the image file onto a DVD or create a bootable USB disk.</p>
                 </div>
                 <div class="four-col last-col no-margin-bottom">
-                    <form class="form-download gap-from-top" action="http://cdimage.ubuntu.com/ubuntukylin/releases/{{latest_release}}/release/ubuntukylin-{{latest_release}}-desktop-amd64.iso" method="get">
-                        <fieldset>
-                            <div>
-                                <button type="submit" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '{{latest_release}} 64 bit', 'From English-language Chinese download']);">Download 64-bit</button>
-                            </div>
-                        </fieldset>
-                    </form>
-                    <form class="form-download" action="http://cdimage.ubuntu.com/ubuntukylin/releases/{{latest_release}}/release/ubuntukylin-{{latest_release}}-desktop-i386.iso" method="get">
-                        <fieldset>
-                            <div>
-                                <button type="submit" class="link-cta-ubuntu cta-large" onclick="_gaq.push(['_trackEvent', 'Download Link', '{{latest_release}} 32 bit', 'From English-language Chinese download']);">Download 32-bit</button>
-                            </div>
-                        </fieldset>
-                    </form>
-            <p class="note">If you have an older PC with less than 2GB of memory, choose the 32-bit download.</p>
+                    <p>
+                        <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/{{latest_release}}/release/ubuntukylin-{{latest_release}}-desktop-amd64.iso" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : '{{latest_release}} 64 bit', 'eventLabel' : 'Ubuntu Kylin', 'eventValue' : undefined });"
+                        >Download (64-bit)</a></p>
+                    <p>
+                        <a href="http://cdimage.ubuntu.com/ubuntukylin/releases/{{latest_release}}/release/ubuntukylin-{{latest_release}}-desktop-i386.iso" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : '{{latest_release}} 32 bit', 'eventLabel' : 'Ubuntu Kylin', 'eventValue' : undefined });"
+                        >Download (32-bit)</a></p>
+                    <p class="note">If you have an older PC with less than 2GB of memory, choose the 32-bit download.</p>
                 </div>
             </div>
-            <p class="intro"><a class="external" href="http://www.ubuntu-china.cn" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Download Kylin hero', 'eventLabel' : 'From Ubuntu download kylin', 'eventValue' : undefined });">Ubuntu中国站</a></p>
+            <p class="intro"><a class="external" href="http://www.ubuntu-china.cn" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'go to China website', 'eventLabel' : 'From Ubuntu download kylin', 'eventValue' : undefined });">Ubuntu中国站</a></p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Done

* corrected lts variable on alternate downloads
* add some GTM tags
* removed dup requirements on desktop

## QA

1. go to /download/server and see there is not form on latest release
2. go to /download/ubuntu-kylin and see the buttons have the arch versions
3. go to /downloads/alternative-downloads and see the 16.04 bit torrent links are correct
4. go to /downloads/desktop and see dup requirement are removed

