### PR TITLE
add point to lts release notes text link

### DIFF
--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -21,7 +21,7 @@
                 <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
                     <h2>Ubuntu Server {{lts_release_full_with_point}}</h2>
                     <p>The Long Term Support version of Ubuntu Server, including the {{openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
-                    <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release_full}} release notes</a></p>
+                    <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release_full_with_point}} release notes</a></p>
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
                     <p><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Server', 'eventLabel' : '{{lst_release_full}}', 'eventValue' : undefined });">Download</a></p>


### PR DESCRIPTION
## Done

* change release notes to use the variable - lts_release_full_with_point 

## QA

1. go to /download/server and see the release notes text has the point release

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/19318600/45605dd8-90a1-11e6-945f-ae399c739cd8.png)

