### PR TITLE
updating row-landscape across /desktop section

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -171,14 +171,15 @@
     </div>
 </section>
 
-<section class="row no-border row-landscape strip-light">
+<section class="row row-landscape strip-light">
     <div class="strip-inner-wrapper">
-        <div class="five-col">
-            <div>
-                <h3>Support tailored to developers&rsquo; needs</h3>
-                <p>With Ubuntu Advantage and Landscape, you can standardise your developer workstations. It helps you manage updates, security patches, and reporting, while minimising downtime. Give your developers the freedom they want while retaining the control you need.</p>
-                <p><a href="/support/">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
-            </div>
+        <div class="six-col no-margin-bottom">
+            <h3>Support tailored to developers&rsquo; needs</h3>
+            <p>With Ubuntu Advantage and Landscape, you can standardise your developer workstations. It helps you manage updates, security patches, and reporting, while minimising downtime. Give your developers the freedom they want while retaining the control you need.</p>
+            <p><a href="/support/">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+        </div>
+        <div class="six-col last-col not-for-small">
+            <img src="{{ ASSET_SERVER_URL }}4125e046-landscape_activity.png" alt="" />
         </div>
     </div>
 </section>

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -140,12 +140,13 @@
 
 <section class="row no-border row-landscape strip-light">
     <div class="strip-inner-wrapper">
-        <div class="five-col">
-            <div>
-                <h2>Support and management tools for&nbsp;your school</h2>
-                <p>Ubuntu Advantage is the professional support package from the experts at Canonical. Get 24x7 support with access to engineers with first-hand experience of your issues. It also includes Landscape, the Ubuntu systems management tool, for monitoring, managing, patching and compliance reporting on all your Ubuntu desktops.</p>
-                <p><a href="/support">Learn about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
-            </div>
+        <div class="six-col no-margin-bottom">
+            <h2>Support and management tools for&nbsp;your school</h2>
+            <p>Ubuntu Advantage is the professional support package from the experts at Canonical. Get 24x7 support with access to engineers with first-hand experience of your issues. It also includes Landscape, the Ubuntu systems management tool, for monitoring, managing, patching and compliance reporting on all your Ubuntu desktops.</p>
+            <p><a href="/support">Learn about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+        </div>
+        <div class="six-col last-col not-for-small">
+            <img src="{{ ASSET_SERVER_URL }}4125e046-landscape_activity.png" alt="" />
         </div>
     </div>
 </section>

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -36,7 +36,7 @@
                 <li>Virus free and highly secure</li>
                 <li>On-site consulting services and training available</li>
                 <li class="last-item">Long-term support releases come with five years of security patches and updates</li>
-    
+
             </ul>
         </div>
     </div>
@@ -66,12 +66,12 @@
 
 <section class="row row-landscape strip-light">
     <div class="strip-inner-wrapper">
-        <div class="five-col no-margin-bottom">
+        <div class="six-col no-margin-bottom">
             <h2>Enterprise-wide support and management tools</h2>
             <p>Ubuntu Advantage is the professional support package from the experts at Canonical. Get 24x7 support with access to engineers with first-hand experience of your issues. It also includes Landscape, the Ubuntu systems management tool, for monitoring, managing, patching and compliance reporting on all your Ubuntu desktops.</p>
             <p><a href="/support">Learn about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="seven-col last-col not-for-small">
+        <div class="six-col last-col not-for-small">
             <img src="{{ ASSET_SERVER_URL }}4125e046-landscape_activity.png" alt="" />
         </div>
     </div>
@@ -79,7 +79,7 @@
 
 {% include "shared/_release_schedule.html" %}
 
-<section class="row no-border row-certified strip-light"> 
+<section class="row no-border row-certified strip-light">
     <div class="strip-inner-wrapper">
         <div class="five-col push-seven last-col">
             <div>

--- a/templates/desktop/government.html
+++ b/templates/desktop/government.html
@@ -79,14 +79,15 @@
     </div>
 </section>
 
-<section class="row no-border row-landscape strip-light">
-    <div class="strip-inner-wrapper equal-height">
-        <div class="five-col equal-height__item">
-            <div>
-                <h2>Government-wide support and management tools</h2>
-                <p>Ubuntu Advantage is the professional support package from the experts at Canonical. Get 24x7 support with access to engineers with first-hand experience of your issues. It also includes Landscape, the Ubuntu systems management tool, for monitoring, managing, patching and compliance reporting on all your Ubuntu desktops.</p>
-                <p><a href="/support">Learn about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
-            </div>
+<section class="row row-landscape strip-light">
+    <div class="strip-inner-wrapper">
+        <div class="six-col no-margin-bottom">
+            <h2>Government-wide support and management tools</h2>
+            <p>Ubuntu Advantage is the professional support package from the experts at Canonical. Get 24x7 support with access to engineers with first-hand experience of your issues. It also includes Landscape, the Ubuntu systems management tool, for monitoring, managing, patching and compliance reporting on all your Ubuntu desktops.</p>
+            <p><a href="/support">Learn about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+        </div>
+        <div class="six-col last-col not-for-small">
+            <img src="{{ ASSET_SERVER_URL }}4125e046-landscape_activity.png" alt="" />
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done

* made all the row-landscapes use the image from /desktop/enterprise

## QA

1. go to the following pages and see the row-landscapes are all the same

* /desktop/government
* /desktop/developer
* /desktop/education
* /desktop/enterprise

