### PR TITLE
Fix padding in desktop header and padding in China

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -594,9 +594,16 @@ body {
     @media only screen and (min-width : $breakpoint-medium) {
       padding: 40px 10px 20px;
     }
+
     @media only screen and (min-width : $breakpoint-large) {
       padding: 100px 40px;
     }
+  }
+}
+
+.desktop-home .row-hero {
+  @media only screen and (min-width: $breakpoint-medium) {
+    padding-top: 80px;
   }
 }
 

--- a/templates/desktop/ubuntu-kylin.html
+++ b/templates/desktop/ubuntu-kylin.html
@@ -13,8 +13,8 @@
 {% block content %}
 <section class="row row-hero strip-light">
     <div class="strip-inner-wrapper">
-        <h1>Ubuntu Kylin for&nbsp;China</h1>
         <div class="six-col">
+            <h1>Ubuntu Kylin for&nbsp;China</h1>
             <p>Ubuntu Kylin is an official flavour of Ubuntu. It is a free PC operating system created for China and complies with the Chinese government procurement regulations. It includes all the features you&rsquo;ve come to expect from Ubuntu, alongside essential Chinese software and apps. The interface has been designed specifically to put Chinese users first &mdash; and with support for touch screens and HiDPI monitors, it runs beautifully on all kinds of hardware.</p>
             <p><a href="http://cn.ubuntu.com" class="button--primary">Ubuntu 中国网站现已面世</a></p>
             <p><a href="/download/ubuntu-kylin">Download Ubuntu Kylin&nbsp;&rsaquo;</a></p>
@@ -61,7 +61,7 @@
     </div>
 </section>
 
-<section class="row no-border no-padding-bottom strip-light">
+<section class="row strip-light">
     <div class="strip-inner-wrapper">
         <h2>What&rsquo;s new in Ubuntu {{latest_release_full}}?</h2>
 
@@ -82,7 +82,7 @@
     </div>
 </div>
 
-<section class="row no-border no-padding-bottom">
+<section class="row no-padding-bottom">
     <div class="strip-inner-wrapper">
         <div class="six-col append-two">
             <div>


### PR DESCRIPTION
## Done
- Fixes the position of the title on the /desktop page to match other sections
- Moved the title into the six-col on /desktop/ubuntu-kylin so the image doesnt appear over it
- Removed the no-padding-bottom and no-borders from the "What’s new in Ubuntu 16.10?" section in /desktop/ubuntu-kylin

## QA
- Go to /desktop, open another page in another tab and check the row-hero titles appear in the same section
- Go to /desktop/ubuntu-kylin check the title is not overlapped by the image [1]
![ubuntu kylin ubuntu](https://cloud.githubusercontent.com/assets/1413534/19342064/2here is padding at the bottom on borders. See demo for reference: http://www.ubuntu.com-master.demo.haus/desktop/ubuntu-kylin

## Screenshots
[1] 
![ubuntu kylin ubuntu](https://cloud.githubusercontent.com/assets/1413534/19342064/264544cc-9128-11e6-917f-0cdba0ef7b37.png)

