### PR TITLE
Replace certification links

### DIFF
--- a/static/js/global.js
+++ b/static/js/global.js
@@ -4,7 +4,7 @@ var ai = [
   { url: "https://askubuntu.com", title:"Ask!" },
   { url: "https://developer.ubuntu.com", title:"Developer" },
   { url: "https://design.ubuntu.com", title:"Design" },
-  { url: "http://www.ubuntu.com/certification", title:"Hardware" },
+  { url: "https://certification.ubuntu.com", title:"Hardware" },
   { url: "https://insights.ubuntu.com", title:"Insights" },
   { url: "https://jujucharms.com", title:"Juju" },
   { url: "http://maas.ubuntu.com", title:"MAAS" },
@@ -98,11 +98,6 @@ core.getActive = function(link) {
   var fullurl = core.getURL();
   var url = fullurl.substr(0,link.length);
 
-  if(link == 'http://www.ubuntu.com') {
-    if(fullurl.substr(0,35) == 'http://www.ubuntu.com/certification' ){
-      return '';
-    }
-  }
   return (url == link)?'class="active"':'';
 };
 

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -132,7 +132,7 @@
             <div class="seven-col">
                 <h2>By developers, for developers</h2>
                 <p>Ubuntu is the result of contributions by thousands of developers, motivated by the desire to create their own perfect developer environment. That&rsquo;s why it&rsquo;s used by some of the world&rsquo;s most exciting technology companies and it&rsquo;s why Valve decided to port its hugely popular Steam virtual games store to Ubuntu. Ubuntu runs on architectures from x86 to ARM and on cloud platforms from OpenStack to Azure and EC2. This versatility makes it the ideal choice for companies with a diverse hardware infrastructure.</p>
-                <p><a class="external" href="http://ubuntu.com/certification/desktop">See all Ubuntu certified PCs</a></p>
+                <p><a class="external" href="https://certification.ubuntu.com/desktop">See all Ubuntu certified PCs</a></p>
             </div>
             <div class="five-col last-col">
                 <img src="{{ ASSET_SERVER_URL }}7d0573d2-desktop-developer-developers.jpg" alt="Developer laptop" />

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -85,7 +85,7 @@
             <div>
                 <h2>Pre-installed on certified&nbsp;hardware</h2>
                 <p>Ubuntu runs on the world&rsquo;s best hardware from partners such as Dell, HP and Lenovo. And with nearly 90% of PCs shipped by the major PC companies already certified to work with Ubuntu, it is easy to find hardware that will work for your business.</p>
-                <p><a href="/certification/">Learn more about Ubuntu certified hardware&nbsp;&rsaquo;</a></p>
+                <p><a href="https://certification.ubuntu.com/">Learn more about Ubuntu certified hardware&nbsp;&rsaquo;</a></p>
             </div>
         </div>
     </div>

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -116,7 +116,7 @@
         <div class="six-col">
             <h2>Ubuntu Desktop certified hardware</h2>
             <p>To offer top performance on Ubuntu, global and local manufacturers are pre-loading devices with an Ubuntu Certified image. This ensures driver integration and superior device performance.  Canonical is committed to working closely with with the world&rsquo;s leading manufacturers to optimise and certify Ubuntu on their laptops and PCs.</p>
-            <p><a href="/certification">Learn more about Ubuntu Certified hardware&nbsp;&rsaquo;</a></p>
+            <p><a href="https://certification.ubuntu.com">Learn more about Ubuntu Certified hardware&nbsp;&rsaquo;</a></p>
         </div>
         <div class="six-col last-col">
             <img class="touch-border" src="{{ ASSET_SERVER_URL }}f1d1b842-desktop-overview-hardware.jpg" alt="Photo of laptop running Ubuntu" />

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -15,7 +15,6 @@
             <h1>Ubuntu Server for ARM</h1>
             <p>Ubuntu {{lts_release_full_with_point}} includes support for the very latest ARM-based server systems powered by certified 64-bit processors.</p>
             <p>Develop and test using over 50,000 software packages and runtimes &mdash; including Go, Java, Javascript, PHP, Python and Ruby &mdash; and deploy at scale using our complete scale-out management suite including MAAS and Juju. Ubuntu delivers server-grade performance on ARM, while fully retaining the reliable and familiar Ubuntu experience.</p>
-            <!-- p><a class="external" href="https://certification.ubuntu.com/soc/">See all certified ARM systems</a></p -->
         </div>
         <div class="twelve-col box box-highlight">
             <div class="twelve-col no-margin-bottom equal-height--vertical-divider">

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -15,7 +15,7 @@
             <h1>Ubuntu Server for ARM</h1>
             <p>Ubuntu {{lts_release_full_with_point}} includes support for the very latest ARM-based server systems powered by certified 64-bit processors.</p>
             <p>Develop and test using over 50,000 software packages and runtimes &mdash; including Go, Java, Javascript, PHP, Python and Ruby &mdash; and deploy at scale using our complete scale-out management suite including MAAS and Juju. Ubuntu delivers server-grade performance on ARM, while fully retaining the reliable and familiar Ubuntu experience.</p>
-            <!-- p><a class="external" href="http://www.ubuntu.com/certification/soc/">See all certified ARM systems</a></p -->
+            <!-- p><a class="external" href="https://certification.ubuntu.com/soc/">See all certified ARM systems</a></p -->
         </div>
         <div class="twelve-col box box-highlight">
             <div class="twelve-col no-margin-bottom equal-height--vertical-divider">

--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -52,7 +52,7 @@
             </li>
             <li id="support-scope-hardware"><span class="number">2.2</span> Hardware
                 <ul>
-                    <li>Ubuntu Certified hardware has passed our extensive testing and review process. More information about the Ubuntu certification process and a list of certified hardware can be found on the Ubuntu Certification page: <a href="/certification">www.ubuntu.com/certification</a>.  The services apply only with respect to the customer&#39;s hardware which has been certified.  In the event the customer requests the services with respect to hardware which is not certified, Canonical will use reasonable efforts to provide support services, but may not adhere to the obligations described in this service description.</li>
+                    <li>Ubuntu Certified hardware has passed our extensive testing and review process. More information about the Ubuntu certification process and a list of certified hardware can be found on the Ubuntu Certification page: <a href="https://certification.ubuntu.com">www.ubuntu.com/certification</a>.  The services apply only with respect to the customer&#39;s hardware which has been certified.  In the event the customer requests the services with respect to hardware which is not certified, Canonical will use reasonable efforts to provide support services, but may not adhere to the obligations described in this service description.</li>
                 </ul>
             </li>
             <li id="support-scope-packages"><span class="number">2.3</span> Packages

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -200,7 +200,7 @@
                 </li>
               {% endfor %}
             </ul>
-            <p class="align-center"><a href="/certification">View all certified hardware&nbsp;&rsaquo;</a></p>
+            <p class="align-center"><a href="https://certification.ubuntu.com">View all certified hardware&nbsp;&rsaquo;</a></p>
         </div>
     </div>
 </section>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -112,7 +112,7 @@
                 <img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}b5352dc1-logo-arm.svg" alt="Intel" />
             </li>
         </ul>
-        <p class="text-center twelve-col"><a href="/certification">View all certified hardware&nbsp;&rsaquo;</a></p>
+        <p class="text-center twelve-col"><a href="https://certification.ubuntu.com">View all certified hardware&nbsp;&rsaquo;</a></p>
     
         <ul class="inline-logos">
             <li class="inline-logos__item">


### PR DESCRIPTION
QA
--

Click around, find links to certification, check they go to https://certification.ubuntu.com (and break ;) )