### PR TITLE
fix /desktop/enterprise for small screen

### DIFF
--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -42,7 +42,7 @@
     </div>
 </section>
 
-<section class="row strip-dark no-border">
+<section class="row row-case-studies strip-dark no-border">
     <div class="strip-inner-wrapper">
         <div class="twelve-col">
             <h2>Ubuntu in action</h2>
@@ -66,7 +66,7 @@
 
 <section class="row row-landscape strip-light">
     <div class="strip-inner-wrapper">
-        <div class="six-col no-margin-bottom">
+        <div class="six-col">
             <h2>Enterprise-wide support and management tools</h2>
             <p>Ubuntu Advantage is the professional support package from the experts at Canonical. Get 24x7 support with access to engineers with first-hand experience of your issues. It also includes Landscape, the Ubuntu systems management tool, for monitoring, managing, patching and compliance reporting on all your Ubuntu desktops.</p>
             <p><a href="/support">Learn about Ubuntu Advantage&nbsp;&rsaquo;</a></p>

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -3,7 +3,7 @@
         <div class="seven-col equal-height__item equal-height__align-vertically">
             <div>
                 <h3>Ubuntu release cycle</h3>
-                <img src="{{ ASSET_SERVER_URL }}a5f068c2-desktop-release-eol.png?w=540"
+                <img class="seven-col" src="{{ ASSET_SERVER_URL }}a5f068c2-desktop-release-eol.png?w=540"
                     srcset="{{ ASSET_SERVER_URL }}a5f068c2-desktop-release-eol.png?w=431 880w,
                     {{ ASSET_SERVER_URL }}a5f068c2-desktop-release-eol.png?w=305 980w,
                     {{ ASSET_SERVER_URL }}a5f068c2-desktop-release-eol.png?w=540 1064w"


### PR DESCRIPTION
## Done

* fix up /desktop/enterprise on small screen

## QA

- [ ] /enterprise: in small screen, can the image in "A release schedule" be full width?
- [ ] /enterprise: in small screen, the "Enterprise-wide support and management tools" row doesn't have bottom padding
- [ ] /enterprise: in small screen, the first link in the "Ubuntu in action" row is too close to pull quote above it (compare with quotes in /government, looks better)

## Issue / Card

[trello](https://trello.com/c/Rcx17E57)