### PR TITLE
update laptop for small screen on desktop/partners

### DIFF
--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -639,6 +639,25 @@
     }
   }
 
+  .row-certified-hardware {
+
+    &__image {
+      min-height: 225px;
+
+      > img {
+        width: 330px;
+      }
+
+      @media only screen and (min-width: $breakpoint-medium) {
+        min-height: 200px;
+
+        > img {
+          width: 100%;
+        }
+      }
+    }
+  }
+
   .row-intel {
     background-color: #007cc5;
     color: $white;

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -111,14 +111,14 @@
     </div>
 </section>
 
-<section class="row no-border strip-light">
+<section class="row row-certified-hardware no-border strip-light">
     <div class="strip-inner-wrapper">
         <div class="six-col">
             <h2>Ubuntu Desktop certified hardware</h2>
             <p>To offer top performance on Ubuntu, global and local manufacturers are pre-loading devices with an Ubuntu Certified image. This ensures driver integration and superior device performance.  Canonical is committed to working closely with with the world&rsquo;s leading manufacturers to optimise and certify Ubuntu on their laptops and PCs.</p>
             <p><a href="/certification">Learn more about Ubuntu Certified hardware&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="six-col last-col">
+        <div class="six-col last-col row-certified-hardware__image">
             <img class="touch-border" src="{{ ASSET_SERVER_URL }}f1d1b842-desktop-overview-hardware.jpg" alt="Photo of laptop running Ubuntu" />
       	</div>
     </div>


### PR DESCRIPTION
## Done

* fixed small screen laptop image from cropping

## QA

1. go to /desktop/partners in small screen, the image in "Ubuntu Desktop certified hardware" shouldn't be cropped

## Issue / Card

[trello](https://trello.com/c/fMasqQOO)

