### PR TITLE
Only remove row-videos border on biggish screens

### DIFF
--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -199,6 +199,12 @@
     }
   }
 
+  .row-videos {
+    @media only screen and (min-width: $breakpoint-medium) {
+      border-bottom: 0;
+    }  
+  }
+
   .row-gaming {
 
     @media only screen and (min-width: $breakpoint-medium) {

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -70,7 +70,7 @@
                     <p>Mobile and desktop messaging app with a focus on security and speed.</p>
                 </div>
             </li>
-    
+
             <li class="grid-list__item four-col">
                 <div class="grid-list__icon one-col ">
                     <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}171fcf42-Chromium_11_Logo.svg?fmt=png&w=60" alt="Chromium icon" />
@@ -80,7 +80,7 @@
                     <p>A fast, simple and secure web browser, built for the modern web.</p>
                 </div>
             </li>
-    
+
             <li class="grid-list__item four-col last-col">
                 <div class="grid-list__icon one-col ">
                     <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}6b138bd2-thunderbird-icon.png" alt="Thunderbird icon" />
@@ -90,7 +90,7 @@
                     <p>Terrific email application, from Mozilla, that&rsquo;s easy to set up and customise.</p>
                 </div>
             </li>
-    
+
             <li class="grid-list__item four-col">
                 <div class="grid-list__icon one-col ">
                     <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}34214609-dropbox-icon.png" alt="Dropbox icon" />
@@ -100,7 +100,7 @@
                     <p>The world&rsquo;s favourite cloud backup and file sharing service.</p>
                 </div>
             </li>
-    
+
             <li class="grid-list__item four-col">
                 <div class="grid-list__icon one-col ">
                     <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}55264c66-libreoffice-icon.png" alt="LibreOffice icon" />
@@ -110,7 +110,7 @@
                     <p>The free office productivity suite that&rsquo;s compatible with Microsoft Office.</p>
                 </div>
             </li>
-    
+
             <li class="grid-list__item four-col last-col">
                 <div class="grid-list__icon one-col ">
                     <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}7fa9fe86-twitter-icon.png" alt="Twitter icon" />
@@ -120,7 +120,7 @@
                     <p>The social media powerhouse that&rsquo;s become an essential for online life.</p>
                 </div>
             </li>
-    
+
             <li class="grid-list__item four-col last-row">
                 <div class="grid-list__icon one-col ">
                     <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}7b460167-vlc-icon.png" alt="VLC icon" />
@@ -130,7 +130,7 @@
                     <p>No other video player is compatible with as many different file formats.</p>
                 </div>
             </li>
-    
+
             <li class="grid-list__item four-col last-row">
                 <div class="grid-list__icon one-col ">
                     <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}5c9184f1-gimp-icon.png" alt="Gimp icon" />
@@ -140,7 +140,7 @@
                     <p>The world&rsquo;s number one free app for image creation and photo retouching.</p>
                 </div>
             </li>
-    
+
             <li class="grid-list__item four-col last-row last-col">
                 <div class="grid-list__icon one-col ">
                     <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}21cf063d-firefox-icon.png" alt="Firefox icon" />
@@ -224,7 +224,7 @@
             <p>With Shotwell, you can quickly and easily import, organise, edit and view your pictures. And you can share your favourite snaps on all popular photo sites and social networks.</p>
         </div>
         <div class="equal-height--vertical-divider__item five-col last-col">
-            <h2>Edit and illustrate</h2> 
+            <h2>Edit and illustrate</h2>
             <p>Edit your photos or create professional illustrations and designs with tools like Gimp and Inkscape, available in the Ubuntu Software Centre.</p>
             <ul class="inline-list">
                 <li>
@@ -244,7 +244,7 @@
     </div>
 </div>
 
-<div class="row row-videos no-border">
+<div class="row row-videos">
     <div class="strip-inner-wrapper equal-height">
         <div class="four-col append-one equal-height__item equal-height__align-vertically">
             <div>


### PR DESCRIPTION
QA
---

On `/desktop/features`, check there is still no border between "Videos" and "Gaming" on a large screen, but on smaller screens, when there's no background image for "Gaming", the border should appear.