### PR TITLE
Small screens: Remove "Smarter searching" image

### DIFF
--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -276,7 +276,7 @@
                 <p>By enabling online search, smart filters make it faster and easier to find the content you need, whether it’s stored on your computer or on the web. Type any query into the Dash home and the Smart Scopes server will determine which categories of content are the most relevant to your search, returning only the best results. And it learns from your past searches making it increasingly accurate over time.</p>
             </div>
         </div>
-        <img src="{{ ASSET_SERVER_URL }}bcb09a5b-desktop-features-smarter-searching.jpg?op=region&amp;rect=140,0,910,300" class="touch-border" alt="Unity search" width="910" />
+        <img src="{{ ASSET_SERVER_URL }}bcb09a5b-desktop-features-smarter-searching.jpg?op=region&amp;rect=140,0,910,300" class="touch-border not-for-small" alt="Unity search" width="910" />
     </div>
 </div>
 


### PR DESCRIPTION
QA
--

Visit `/desktop/features`. See the image in the "Smarter searching" row? Shrink the screen size. At the small screen layout, the image should be gone. As if it was never there.