### PR TITLE
small screen fixes for /desktop overview

### DIFF
--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -133,20 +133,16 @@
       margin: 0 auto 10px;
       max-width: 150px;
     }
+
+    .muted-heading {
+      @media only screen and (min-width: $breakpoint-medium) {
+        margin-bottom: 3em;
+      }
+    }
   }
 
   .row-latest-hardware {
-    margin-bottom: 20px;
-
-    @media only screen and (min-width: $breakpoint-medium) {
-      margin-bottom: 0;
-    }
-
-    .no-margin-bottom {
-      @media only screen and (max-width: $breakpoint-medium) {
-        margin-bottom: 20px;
-      }
-    }
+    margin-bottom: 0;
   }
 }
 

--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -142,6 +142,16 @@
   }
 
   .row-latest-hardware {
+    .row-latest-hardware__image {
+        margin-bottom: 20px;
+
+        @media only screen and (min-width: $breakpoint-medium) {
+          margin-bottom: 0;
+        }
+    }
+  }
+
+  .row-latest-hardware {
     margin-bottom: 0;
   }
 }

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -98,7 +98,7 @@
 
 <section class="row no-padding-bottom row-latest-hardware strip-light">
     <div class="strip-inner-wrapper equal-height">
-        <div class="seven-col no-margin-bottom equal-height__item">
+        <div class="seven-col equal-height__item row-latest-hardware__image">
             <img class="left" src="{{ ASSET_SERVER_URL }}5ea4959b-desktop-overview-video.jpg" alt="Whatsnew screenshot">
         </div>
         <div class="four-col prepend-one last-col equal-height__item equal-height__align-vertically">


### PR DESCRIPTION
## Done

* fixes for whitespace on /desktop

## QA

- [x] in small screen, there is grey gap between "Looks great on the latest devices" and "Available on a huge range…"
- [x]  muted heading in industry sectors too close to icons

## Issue / Card

[trello card](https://trello.com/c/QsTO0xTS)