### PR TITLE
Right padding on "Do you want to upgrade?"

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -122,7 +122,7 @@
         border-radius: 0 0 4px 4px;
         display: block;
         margin-bottom: 0;
-        padding: 20px 0 20px 84px;
+        padding: 20px 20px 20px 84px;
         margin: 0 -20px -41px -20px;
     }
 }


### PR DESCRIPTION
Fixes #955.

QA
--

Go to /download, make screen really quite small, check "Follow our simple guide >" text never touches edge of box.