### PR TITLE
Flip last row of /desktop/enterprise

### DIFF
--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -334,7 +334,7 @@
   .row-certified {
     @media only screen and (min-width: $breakpoint-medium) {
       background-image: url('#{$asset-server}31a45631-desktop-enterprise-certified.jpg');
-      background-position: 0% 39%;
+      background-position: 93% 39%;
       background-repeat: no-repeat;
       background-size: 56%;
       min-height: 373px;

--- a/templates/desktop/enterprise.html
+++ b/templates/desktop/enterprise.html
@@ -81,7 +81,7 @@
 
 <section class="row no-border row-certified strip-light">
     <div class="strip-inner-wrapper">
-        <div class="five-col push-seven last-col">
+        <div class="five-col">
             <div>
                 <h2>Pre-installed on certified&nbsp;hardware</h2>
                 <p>Ubuntu runs on the world&rsquo;s best hardware from partners such as Dell, HP and Lenovo. And with nearly 90% of PCs shipped by the major PC companies already certified to work with Ubuntu, it is easy to find hardware that will work for your business.</p>


### PR DESCRIPTION
## Done

Flip the last row of /desktop/enterprise so the image is on the right.
As it stands before, the text on the last two rows are on the same side and misaligned.

## QA

Make sure image is on right and looks pretty.

## Screenshots
Previously:

![selection_012](https://cloud.githubusercontent.com/assets/322693/19346220/2c0da09a-913a-11e6-9756-df79b19f78b3.png)


