### PR TITLE
Design review todos cloud section

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -344,23 +344,32 @@
 .cloud-training  {
 
   .row-hero {
-
+    position: relative;
+    
     @media only screen and (min-width : $breakpoint-medium) {
       min-height: 343px;
     }
   }
 
-  .row--training__image {
-    position: absolute;
-
-    @media only screen and (min-width : $breakpoint-medium) {
-      right: -20px;
-      top: -84px;
+  .row--training {
+    position: relative;
+    
+    &__content {
+      position: relative;
     }
-
-    @media only screen and (min-width : $breakpoint-large) {
-      right: -40px;
-      top: -121px;
+    
+    &__image {
+      position: absolute;
+  
+      @media only screen and (min-width : $breakpoint-medium) {
+        right: 20px;
+        top: -40px;
+      }
+  
+      @media only screen and (min-width : $breakpoint-large) {
+        right: 40px;
+        top: -100px;
+      }
     }
   }
 }
@@ -551,7 +560,7 @@
 
   @media only screen and (min-width : $breakpoint-medium) {
     #main-content .row-hero {
-      background-image: url('#{$asset-server}85280667-image-cloud-openstack-autopilot-screenshot.jpg?op=region&rect=0,0,450,800');
+      background-image: url('#{$asset-server}85280667-image-cloud-openstack-autopilot-screenshot.jpg?op=region&rect=0,0,500,900');
       background-position: 122% 0%;
       background-repeat: no-repeat;
     }

--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -560,7 +560,7 @@
 
   @media only screen and (min-width : $breakpoint-medium) {
     #main-content .row-hero {
-      background-image: url('#{$asset-server}85280667-image-cloud-openstack-autopilot-screenshot.jpg?op=region&rect=0,0,500,900');
+      background-image: url('#{$asset-server}85280667-image-cloud-openstack-autopilot-screenshot.jpg?op=region&rect=0,0,450,900');
       background-position: 122% 0%;
       background-repeat: no-repeat;
     }

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -334,8 +334,10 @@
 
 <section class="row no-border">
     <div class="strip-inner-wrapper">
-        <p id="fn1" class="note"><a href="#r1">*</a> <a href="http://thecloudmarket.com/stats#/by_platform_definition" class="external">The Cloud Market</a>, August 2015 and <a href="http://superuser.openstack.org/articles/openstack-users-share-how-their-deployments-stack-up" class="external">OpenStack survey &mdash; May 2015</a></p>
-        <p id="fn2" class="note"><a href="#r2">**</a> <a href="http://www.zdnet.com/article/ubuntu-linux-continues-to-rule-the-cloud/" class="external">zdnet.com</a>, 27 August 2015</p>
+        <div class="twelve-col">
+            <p id="fn1" class="note"><a href="#r1">*</a> <a href="http://thecloudmarket.com/stats#/by_platform_definition" class="external">The Cloud Market</a>, August 2015 and <a href="http://superuser.openstack.org/articles/openstack-users-share-how-their-deployments-stack-up" class="external">OpenStack survey &mdash; May 2015</a></p>
+            <p id="fn2" class="note"><a href="#r2">**</a> <a href="http://www.zdnet.com/article/ubuntu-linux-continues-to-rule-the-cloud/" class="external">zdnet.com</a>, 27 August 2015</p>
+        </div>
     </div>
 </section>
 

--- a/templates/cloud/juju.html
+++ b/templates/cloud/juju.html
@@ -12,7 +12,7 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row row-hero no-border strip-light">
+<section class="row row-hero no-border no-padding-bottom strip-light">
     <div class="strip-inner-wrapper">
         <div class="twelve-col">
             <div class="six-col">

--- a/templates/cloud/storage/index.html
+++ b/templates/cloud/storage/index.html
@@ -137,7 +137,9 @@
                 <li>Built with Ubuntu {{ lts_release_full }} with five years of support for every component in the stack.</li>
             </ul>
         </div>
-        <p class="clear twelve-col"><a href="/cloud/storage/contact-us">Request a demo&nbsp;&rsaquo;</a></p>
+        <div class="clear twelve-col">
+            <p><a href="/cloud/storage/contact-us">Request a demo&nbsp;&rsaquo;</a></p>
+        </div>
     </div>
 </section>
 

--- a/templates/cloud/training/index.html
+++ b/templates/cloud/training/index.html
@@ -14,13 +14,13 @@
 
 {% block outer_content %}
 {% block content %}
-<section class="row row-hero row-training strip-light">
-    <div class="strip-inner-wrapper">
+<section class="row row-hero row--training strip-light">
+    <div class="strip-inner-wrapper row--training__content">
         <h1>Train with Ubuntu</h1>
         <div class="six-col">
             <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of OpenStack.</p>
         </div>
-        <img class="row-training__image not-for-small" alt="" src="{{ ASSET_SERVER_URL }}58f24048-image-ubuntu-openstack-medals.png" />
+        <img class="row--training__image not-for-small" alt="" src="{{ ASSET_SERVER_URL }}58f24048-image-ubuntu-openstack-medals.png" />
     </div>
 </section>
 


### PR DESCRIPTION
## Done

Fix hero image on /cloud/openstack/autopilot
overview: in small screen, the section that has the footnotes has no bottom padding
/cloud/training: can we place the hero image within the grid?

## QA

Check in s/m and l


