### PR TITLE
fix prevous arm downloads on small screens

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -109,8 +109,8 @@
 
         <div class="twelve-col equal-height no-margin-bottom">
             <div class="six-col box">
-                <ul class="inline-logos">
-                    <li class="inline-logos__item"><img class="inline-logos__image not-for-small" src="{{ ASSET_SERVER_URL }}ca664713-partners-logo-apm.svg" alt="" width="150" /></li>
+                <ul class="inline-logos  not-for-small">
+                    <li class="inline-logos__item"><img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}ca664713-partners-logo-apm.svg" alt="" width="150" /></li>
                 </ul>
                 <h3>Applied Micro X-Gene ARMv8</h3>
                 <ul class="no-bullets list">
@@ -119,8 +119,8 @@
                 </ul>
             </div>
             <div class="six-col last-col box">
-                <ul class="inline-logos">
-                    <li class="inline-logos__item"><img class="not-for-small" src="{{ ASSET_SERVER_URL }}f38c9ed1-hpe_pri_grn_pos_rgb.svg" alt="" width="150" /></li>
+                <ul class="inline-logos not-for-small">
+                    <li class="inline-logos__item"><img src="{{ ASSET_SERVER_URL }}f38c9ed1-hpe_pri_grn_pos_rgb.svg" alt="" width="150" /></li>
                 </ul>
                 <h3>HP Moonshot</h3>
                 <ul class="no-bullets list">
@@ -130,8 +130,8 @@
                 </ul>
             </div>
             <div class="six-col box">
-                <ul class="inline-logos">
-                    <li class="inline-logos__item"><img class="not-for-small" src="{{ ASSET_SERVER_URL }}4fc650f0-Marvell_Logo.svg" alt="" width="150" /></li>
+                <ul class="inline-logos not-for-small">
+                    <li class="inline-logos__item"><img src="{{ ASSET_SERVER_URL }}4fc650f0-Marvell_Logo.svg" alt="" width="150" /></li>
                 </ul>
                 <h3>Marvell Armada XP</h3>
                 <ul class="no-bullets list">
@@ -140,8 +140,8 @@
                 </ul>
             </div>
             <div class="six-col last-col box">
-                <ul class="inline-logos">
-                    <li class="inline-logos__item"><img class="not-for-small" src="{{ ASSET_SERVER_URL }}43b35b55-logo-cavium.png" alt="" width="150" /></li>
+                <ul class="inline-logos not-for-small">
+                    <li class="inline-logos__item"><img src="{{ ASSET_SERVER_URL }}43b35b55-logo-cavium.png" alt="" width="150" /></li>
                 </ul>
                 <h3>Cavium Thunder 48 and 96 core ARMv8</h3>
                 <ul class="no-bullets list">


### PR DESCRIPTION
## Done

Added a not-for-small class to the logo containers on /download/alternative-downloads so that they don't have too much blank space at small screen.

## QA

Go to `/download/alternative-downloads`
Behold that, on the smallest viewport, the top padding of "Past ARM releases" boxes looks correct.

## Issue / Card

Fixes #1006 


