### PR TITLE
Position /cloud/openstack/autopilot image like in desktop/features

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -345,7 +345,7 @@
 
   .row-hero {
     position: relative;
-    
+
     @media only screen and (min-width : $breakpoint-medium) {
       min-height: 343px;
     }
@@ -353,19 +353,19 @@
 
   .row--training {
     position: relative;
-    
+
     &__content {
       position: relative;
     }
-    
+
     &__image {
       position: absolute;
-  
+
       @media only screen and (min-width : $breakpoint-medium) {
         right: 20px;
         top: -40px;
       }
-  
+
       @media only screen and (min-width : $breakpoint-large) {
         right: 40px;
         top: -100px;
@@ -447,14 +447,14 @@
 .cloud-juju {
 
   .row-get-started {
-    
+
     @media only screen and (min-width : $breakpoint-medium) {
       background-image: url('#{$asset-server}8149d09f-Service+View+-+zoom.png?w=600');
       background-position: top right;
       background-repeat: no-repeat;
     }
   }
-  
+
   .bundle-card__image-container {
     height: 345px;
   }
@@ -563,9 +563,29 @@
 
   @media only screen and (min-width : $breakpoint-medium) {
     #main-content .row-hero {
-      background-image: url('#{$asset-server}85280667-image-cloud-openstack-autopilot-screenshot.jpg?op=region&rect=0,0,450,900');
-      background-position: 122% 0%;
-      background-repeat: no-repeat;
+      overflow: hidden;
+
+      &:before {
+
+        @media only screen and (min-width : $breakpoint-medium) {
+          background: url('#{$asset-server}b72144a5-cloud_landscape_components.png?w=897') center center no-repeat;
+          background-size: contain;
+          content: '';
+          display: block;
+          height: 75%;
+          overflow: visible;
+          position: absolute;
+          right: -30vw;
+          top: 40px;
+          width: 80vw;
+        }
+
+        @media only screen and (min-width : $breakpoint-large) {
+          height: 100%;
+          right: 3vw;
+          width: 45vw;
+        }
+      }
     }
   }
 
@@ -889,7 +909,7 @@
   .command-line {
     background: $light-grey;
     border: 0;
-    
+
      > code {
       color: $cool-grey;
     }

--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -576,12 +576,12 @@
           overflow: visible;
           position: absolute;
           right: -30vw;
-          top: 40px;
+          top: 60px;
           width: 80vw;
         }
 
         @media only screen and (min-width : $breakpoint-large) {
-          height: 100%;
+          height: 85%;
           right: 3vw;
           width: 45vw;
         }

--- a/templates/cloud/openstack/autopilot.html
+++ b/templates/cloud/openstack/autopilot.html
@@ -37,9 +37,6 @@
                 </a>
             </p>
         </div>
-        <div class="six-col last-col for-small">
-            <img src="{{ ASSET_SERVER_URL }}85280667-image-cloud-openstack-autopilot-screenshot.jpg?op=region&amp;rect=0,0,630,630" alt="Landscape screenshot" />
-        </div>
     </div>
 </section>
 
@@ -93,12 +90,12 @@
                     </a>
                 </p>
             </div>
-    
+
             <div class="three-col box align-center">
                 <h3 class="caps">Free</h3>
                 <p class="intro">Up to ten machines</p>
             </div>
-    
+
             <div class="three-col last-col box align-center">
                 <h3 title="USD">$750</h3>
                 <p class="intro">Annually, per server</p>


### PR DESCRIPTION
- Autopilot hero image should do its best to fill up the space to the right of the hero row
- Should disappear on mobile view

Fixes #983 

QA
--

Go to `/cloud/openstack/autopilot`. Manipulate the page to simulate all manner of screen sizes. Check the image position in all cases renders Lil happy, or at least indifferent.