### PR TITLE
Fix torrents and link to contribute when downloading 16.10

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -56,10 +56,10 @@
         <div class="four-col">
             <h3 class="external--title"><span>Ubuntu {{lts_release_full_with_point}}</span></h3>
             <ul class="no-bullets list">
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-i386.iso.torrent">Ubuntu {{latest_release}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-amd64.iso.torrent">Ubuntu {{latest_release}} Server (64-bit)&nbsp;&rsaquo;</a></li>
-                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-i386.iso.torrent">Ubuntu {{latest_release}} Server (32-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-desktop-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-amd64.iso.torrent">Ubuntu {{lts_release_with_point}} Server (64-bit)&nbsp;&rsaquo;</a></li>
+                <li><a class="download-torrent" href="http://releases.ubuntu.com/{{lts_release_no_point}}/ubuntu-{{lts_release_with_point}}-server-i386.iso.torrent">Ubuntu {{lts_release_with_point}} Server (32-bit)&nbsp;&rsaquo;</a></li>
             </ul>
         </div><!-- /.four-col -->
         <div class="four-col last-col">

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -39,11 +39,11 @@
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
                     <p>
-                        <a class="button--primary link-cta-download" href="/download/desktop/thank-you?version={{lts_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{lst_release_full}}', 'eventValue' : undefined });">Download</a>
+                        <a class="button--primary link-cta-download js-lts-download" href="/download/desktop/thank-you?version={{lts_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{lst_release_full}}', 'eventValue' : undefined });">Download</a>
                         <script>
                             // Contributions only work with JavaScript
                             // So if we have JavaScript, send them to /contribute
-                            var downloadLink = document.querySelector('.link-cta-download');
+                            var downloadLink = document.querySelector('.js-lts-download');
                             var contributeUrl = downloadLink.href.replace('/thank-you', '/contribute');
                             downloadLink.href = contributeUrl;
                         </script>
@@ -70,11 +70,11 @@
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
                     <p>
-                        <a class="button--primary link-cta-download" href="/download/desktop/thank-you/?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a>
+                        <a class="button--primary link-cta-download js-latest-download" href="/download/desktop/thank-you/?version={{latest_release}}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{latest_release_full}}', 'eventValue' : undefined });">Download</a>
                         <script>
                             // Contributions only work with JavaScript
                             // So if we have JavaScript, send them to /contribute
-                            var downloadLink = document.querySelector('.link-cta-download');
+                            var downloadLink = document.querySelector('.js-latest-download');
                             var contributeUrl = downloadLink.href.replace('/thank-you', '/contribute');
                             downloadLink.href = contributeUrl;
                         </script>


### PR DESCRIPTION
## QA
- Go to http://127.0.0.1:8001/download/alternative-downloads
- Check the torrent links are correct for 16.04.1
- Follow the download path to 16.10 and check you hit the contribute page.
