### PR TITLE
remove button styling to leave default on /internet-of-things/digital-signage 

### DIFF
--- a/static/css/section/_things.scss
+++ b/static/css/section/_things.scss
@@ -251,12 +251,6 @@
       @media only screen and (min-width: $breakpoint-medium) {
         background-size: cover;
       }
-
-      a {
-        border-bottom: 1px solid $white;
-        color: $white;
-        text-decoration: none;
-      }
     }
   }
 }


### PR DESCRIPTION
## Done

* removed a {} styling for this block, it only messed it up

## QA

1. go to /internet-of-things/digital-signage and see that the button in section 'Build your own digital signage solution' has orange text

## Issue / Card

Fixes #1016 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/19390899/28ed1be6-9222-11e6-9970-ae4219411862.png)
