### PR TITLE
Redirect all certification URLs

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1745,3 +1745,5 @@ wiki/SetupNdiswrapperHowto/?: "https://wiki.ubuntu.com/"
 wiki/UbuntuDownUnder/?: "https://wiki.ubuntu.com"
 yourcloud/?: "/cloud/openstack/managed-cloud"
 ziskejte/prechod910/?: "/download"
+certification(?P<page>/.*)?: "https://certification.ubuntu.com{page}"
+

--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -1,6 +1,6 @@
 Django==1.9.6
 whitenoise==3.1
-django-yaml-redirects==0.4
+django-yaml-redirects==0.5.3
 django-asset-server-url==0.1
 django-versioned-static-url==0.1.1
 django-template-finder-view==0.2


### PR DESCRIPTION
QA
---

Run site, visit `/certification`, `/certification/desktop` etc. and check you are redirected to the right place.