### PR TITLE
removed some meta keywords from /server/livepatch

### DIFF
--- a/templates/server/livepatch.html
+++ b/templates/server/livepatch.html
@@ -3,7 +3,7 @@
 
 {% block title %}Canonical Livepatch Service | Server{% endblock %}
 {% block meta_description %}The Canonical Livepatch Service for Ubuntu 16.04 servers reduces planned or unplanned downtime whilst keeping on top of compliance and security.{% endblock %}
-{% block meta_keywords %}Canonical Livepatch Service, Kernel Live Patching, Landscape, Server, Ubuntu Advantage, Ubuntu, Ubuntu operating system, OS, platform, Linux, distribution, OpenStack, Ubuntu OpenStack, Ubuntu Cloud, server, tablet, smartphone, phone, Windows alternative, Mac alternative, free software, open source, thin client, Juju, MAAS, Landscape, Ubuntu Advantage, download Ubuntu, deployment, provisioning, service orchestration, services, commercial support, paid support, long term support, LTS, 14.04, 14.10, Trusty Tahr, Utopic Unicorn, Icehouse, Juno{% endblock meta_keywords %}
+{% block meta_keywords %}Canonical Livepatch Service, Kernel Live Patching, Landscape, Server, Ubuntu Advantage, Ubuntu, Ubuntu operating system, OS, platform, Linux, distribution, OpenStack, Ubuntu OpenStack, Ubuntu Cloud, server, tablet, smartphone, phone, Windows alternative, Mac alternative, free software, open source, thin client, Juju, MAAS, Landscape, Ubuntu Advantage, download Ubuntu, deployment, provisioning, service orchestration, services, commercial support, paid support, long term support, LTS{% endblock meta_keywords %}
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">


### PR DESCRIPTION
## Done

Removed some of the meta keywords from /server/livepatch

## QA

 - See that the keyword list on `/server/livepatch` matches the [copydoc](https://docs.google.com/document/d/1ObUSvkDcWOe01pmhh_Aryqxs87D8X2khbJbn3RgqZE0/edit#)
 - Sigh
 - Realise that it really doesn't matter
 - Approve it anyway because you're a perfectionist

