### PR TITLE
revert takeunder from ODS to UA

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -95,7 +95,7 @@
 <section class="row row-featured strip no-border">
     <div class="strip-inner-wrapper equal-height">
         {% include "takeovers/takeunders/_autopilot-takeunder.html" %}
-        {% include "takeovers/takeunders/_ods-2016.html" %}
+        {% include "takeovers/takeunders/_ua-store.html" %}
     </div>
 </section>
 


### PR DESCRIPTION
## Done

Swapped homepage takeunder

## QA

View the homepage and see that the right-hand takeunder is the UA store one.
