### PR TITLE
stop robotics toys image from having its quality reduced

### DIFF
--- a/static/css/section/_internet-of-things.scss
+++ b/static/css/section/_internet-of-things.scss
@@ -176,7 +176,7 @@
     .row-toys {
 
       @media only screen and (min-width: $breakpoint-medium) {
-        background: url('#{$asset-server}9d8a0713-devlopers_2.jpg?q=60&amp;w=1024') center center no-repeat;
+        background: url('#{$asset-server}9d8a0713-devlopers_2.jpg?w=1024') center center no-repeat;
         background-size: cover;
       }
 


### PR DESCRIPTION
## Done

Removed the quality limit from teh background of the toys row on iot robotics.

## QA

Go to `/internet-of-things/robotics` and see the the background to the toys row is no longer fuzzy