### PR TITLE
add a eight-col to a paragraph on the iot robotics page to avoid smal…

### DIFF
--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -155,7 +155,9 @@ feature amazing apps for advanced industrial intelligence.</p>
                 </div>
             </li>
         </ul>
-        <p><a class="external"  href="https://developer.ubuntu.com/en/snappy/?utm_campaign=device-fy17-iot-vertical-robotics-webpage&utm_medium=partnerhardwarelink&utm_source=ubunturobotics">Learn more</a></p>
+        <div class="eight-col">
+            <p><a class="external"  href="https://developer.ubuntu.com/en/snappy/?utm_campaign=device-fy17-iot-vertical-robotics-webpage&utm_medium=partnerhardwarelink&utm_source=ubunturobotics">Learn more</a></p>
+        </div>
     </div>
 </section>
 


### PR DESCRIPTION
## Done

Added an eight-col to a paragraph so that vertical spacing is correct at smaller viewports

## QA

View /internet-of-things/robotics at a smaller viewport and see that the "Ubuntu runs on the robotic platforms that matter" row has the correct vertical spacing at the bottom.