### PR TITLE
Styling update for contact and thank you pages for both IoT and Core

### DIFF
--- a/templates/core/contact-us.html
+++ b/templates/core/contact-us.html
@@ -8,16 +8,20 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row row-hero no-border">
+<section class="row row-hero no-border no-margin-bottom no-padding-bottom strip-light">
     <div class="strip-inner-wrapper">
         <div class="eight-col">
             <h1>Contact us</h1>
             <p>If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch.</p>
         </div>
+	</div>
+</section>
+<section class="row no-border strip-light">
+    <div class="strip-inner-wrapper">
         <div class="eight-col">
             <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
             <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
-        
+
             <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1266">
                 <fieldset>
                     <h3>About you</h3>
@@ -42,7 +46,7 @@
                         {% include "shared/forms/_state.html" %}
                     </ul>
                 </fieldset>
-        
+
                 <fieldset>
                     <h3>About your company</h3>
                     <ul class="no-bullets">
@@ -56,7 +60,7 @@
                         </li>
                     </ul>
                 </fieldset>
-        
+
                 <fieldset>
                     <h3>Your comments</h3>
                     <ul class="no-bullets">
@@ -94,7 +98,7 @@
                     onblur: false
                 });
             </script>
-        
+
         </div>
     </div>
 </section>

--- a/templates/core/thank-you.html
+++ b/templates/core/thank-you.html
@@ -9,7 +9,7 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row no-border equal-height">
+<section class="row no-border equal-height strip-light">
     <div class="strip-inner-wrapper">
         <div class="thank-you eight-col equal-height__item">
             <h1>Thank you for enquiring about Ubuntu core</h1>

--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -8,12 +8,16 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<section class="row row-hero no-border">
+<section class="row row-hero no-border no-margin-bottom no-padding-bottom strip-light">
     <div class="strip-inner-wrapper">
         <div class="eight-col">
             <h1>Contact us</h1>
             <p>If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch.</p>
         </div>
+    </div>
+</section>
+<section class="row no-border strip-light">
+    <div class="strip-inner-wrapper">
         <div class="eight-col">
             <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
             <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>

--- a/templates/shared/_thank_you_footer.html
+++ b/templates/shared/_thank_you_footer.html
@@ -1,5 +1,5 @@
 <div class="row equal-height no-border strip-light">
-  {% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" %}<div class="strip-inner-wrapper">{% endif %}
+  {% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" or level_1 == "core" %}<div class="strip-inner-wrapper">{% endif %}
 	<h2 class="twelve-col">More about our enterprise services</h2>
 	<ul id="thank-you-extra" class="no-bullets">
 		<li class="advantage four-col first">
@@ -18,5 +18,5 @@
 			<p><a href="/support">Learn about Landscape&nbsp;&rsaquo;</a></p>
 		</li>
 	</ul>
-	{% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" %}</div>{% endif %}
+	{% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" or level_1 == "core" %}</div>{% endif %}
 </div><!-- end row-->

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -1,1 +1,38 @@
-[IOT NEWSLETTER SIGN UP]
+<!-- MARKETO FORM -->
+<script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
+<script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+
+<form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1670">
+    <h3>IoT newsletter</h3>
+    <p>Receive regular updates from our IoT newsletter.</p>
+    <ul class="no-bullets">
+        <li  class="mktFormReq mktField">
+            <label for="Email" class="mktoLabel " >Your email address:</label>
+            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" >
+        </li>
+        <li  class="mktField">
+            <input type="hidden" name="utm_source" class="mktoField  mktoFormCol" value="" >
+        </li>
+        <li  class="mktField">
+            <input type="hidden" name="IoT_Newsletters__c" class="mktoField  mktoFormCol" value="True" >
+        </li>
+        <li  class="mktField">
+            <button type="submit" class="mktoButton">Submit</button></span><input type="hidden" name="formid" class="mktoField " value="1670"><input type="hidden" name="lpId" class="mktoField " value="3229"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="//pages.ubuntu.com/Opt-In_IoTNewsletters.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
+        </li>
+    </ul>
+
+    <input type="hidden" name="returnURL" value="http://ubunt.eu/i1jy52" />
+    <input type="hidden" name="retURL" value="http://ubunt.eu/i1jy52" />
+</form>
+<script>
+$("#mktoForm_1670").validate({
+    errorElement: "span",
+    errorClass: "mktFormMsg mktError",
+    onkeyup: false,
+    onclick: false,
+    onblur: false
+});
+
+</script>
+
+<!-- /MARKETO FORM -->


### PR DESCRIPTION
## Done

Updated the markup for
 - IoT Contact / Thank You
 - Core Contact / Thank You

Added a contextual footer newsletter form to the IoT Thank You page

## QA

Check these URLs:
 - /internet-of-things/contact-us
 - /internet-of-things/thank-you
 - /core/contact-us
 - /core/thank-you

On the IoT thank you page, check the new email sign up.