### PR TITLE
Design review tweaks

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -17,12 +17,17 @@
     <div class="strip-inner-wrapper">
         <div class="six-col">
             <h1>Ubuntu Core</h1>
-            <p>Ubuntu Core is a tiny, transactional version of Ubuntu for IoT devices and large container deployments. It runs a new breed of super-secure, remotely upgradeable Linux app packages known as snaps &dash; and it&rsquo;s trusted by leading IoT players, from chipset vendors to device makers and system integrators.</p>
-            <p><a class="button--primary" href="http://developer.ubuntu.com/en/snappy/start/?utm_campaign=Device_FY17_CORE&amp;utm_medium=corepage&amp;utm_source=ubuntuwebsite&amp;utm_content="><span class="external">Download Ubuntu Core</span></a></p>
+            <div class="six-col align-center for-small">
+                <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}53163a88-IOT_core_infographic.svg?w=300" width="300" alt="" />
+            </div>
+            <div class="six-col">
+                <p>Ubuntu Core is a tiny, transactional version of Ubuntu for IoT devices and large container deployments. It runs a new breed of super-secure, remotely upgradeable Linux app packages known as snaps &dash; and it&rsquo;s trusted by leading IoT players, from chipset vendors to device makers and system integrators.</p>
+            </div>
+            <p class="six-col"><a class="button--primary" href="http://developer.ubuntu.com/en/snappy/start/?utm_campaign=Device_FY17_CORE&amp;utm_medium=corepage&amp;utm_source=ubuntuwebsite&amp;utm_content="><span class="external">Download Ubuntu Core</span></a></p>
             <p><a class="external" href="http://snapcraft.io/?utm_campaign=Device_FY17_CORE&amp;utm_medium=corepageintrosection&amp;utm_source=ubuntuwebsite&amp;utm_content=findoutmoreonsnap">Learn more about snaps</a></p>
         </div>
-        <div class="six-col last-col">
-            <img class="row-hero__image not-for-small" src="{{ ASSET_SERVER_URL }}53163a88-IOT_core_infographic.svg" alt="" />
+        <div class="six-col last-col not-for-small">
+            <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}53163a88-IOT_core_infographic.svg?w=600" alt="" />
         </div>
     </div>
 </section>
@@ -60,8 +65,11 @@
             <div class="seven-col equal-height__item">
                 <p>Ubuntu Core uses the same kernel, libraries and system software as classic Ubuntu.  You can develop snaps on your Ubuntu PC just like any other application. The difference is that it&rsquo;s been built for the Internet of Things.</p>
             </div>
-            <div class="five-col last-col equal-height__item equal-height__align-vertically">
+            <div class="five-col last-col equal-height__item equal-height__align-vertically not-for-small">
                 <img src="{{ ASSET_SERVER_URL }}e5202df6-ubuntu-core_black-orange_hex+copy.svg" alt="" />        
+           </div>
+            <div class="align-center five-col for-small no-margin-bottom">
+                <img src="{{ ASSET_SERVER_URL }}e5202df6-ubuntu-core_black-orange_hex+copy.svg" alt="" width="280" />        
            </div>
         </div>
         
@@ -93,7 +101,7 @@
             <p>Ubuntu Core is different from classic Ubuntu distributions. It is purposely lightweight and transactionally updated system, with security at its heart. The fundamental unit is the &ldquo;snap&rdquo; &mdash; a self contained, isolated and protected bit of code that performs a well-defined set of functions.  Even the kernel and core are snaps.</p>
         </div>
         
-        <div class="twelve-col not-for-small" style="padding-top: 2em;">
+        <div class="twelve-col not-for-small align-center" style="padding-top: 2em;">
             <div class="six-col">
                 <h4 class="six-col">Classic Ubuntu 16.04</h4>
             </div>
@@ -103,12 +111,12 @@
             <img src="{{ ASSET_SERVER_URL }}c34c1d3a-Ubuntu+Classic+vs+Core+-+Desktop+%28label%29+%281%29.svg" alt="" />
         </div>
         
-        <div class="twelve-col for-small equal-height--vertical-divider" style="padding-top: 2em;">
+        <div class="align-center twelve-col for-small equal-height--vertical-divider" style="padding-top: 2em;">
             <div class="align-center six-col equal-height--vertical-divider__item">
                 <h3 class="six-col">Classic Ubuntu 16.04</h3>
-                <img src="{{ ASSET_SERVER_URL }}7e9755bf-mobile+-+Infographic-1.svg" alt="" />
+                <img src="{{ ASSET_SERVER_URL }}7e9755bf-mobile+-+Infographic-1.svg" width="260" alt="" />
             </div>
-            <div class="align-center six-col  equal-height--vertical-divider__item last-col">
+            <div class="align-center six-col  equal-height--vertical-divider__item last-col" width="260">
                 <h3 class="six-col">Ubuntu Core 16</h3>
                 <img src="{{ ASSET_SERVER_URL }}e75ed184-mobile+-+Infographic-2.svg" alt="" />
             </div>
@@ -122,9 +130,6 @@
             <div class="six-col">
                 <h3>The smallest Ubuntu</h3>
                 <p>Ubuntu Core is smaller than competing &ldquo;micro&rdquo; container OS offerings. It is small because it&rsquo;s really just a base filesystem. Apps are delivered as snaps, alongside a free choice of container runtimes and coordination systems. And because it&rsquo;s got a smaller attack surface, it&rsquo;s much more secure.</p>
-            </div>
-            <div class="four-col last-col prepend-one no-margin-bottom">
-                <img class="inline-logos__image" src="{{ ASSET_SERVER_URL }}16981ed0-GRAPHIC_os_image_size.svg?w=200" alt="" />
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Done

make ubuntu core logo + os image size graph smaller
on the hero, keep the illustration (between copy and the cta)
make sure we use the same padding between title+ copy and copy + cta?

## QA

check in s/m/l

