### PR TITLE
cleanup and new image for 'why use...' row on Core

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -60,19 +60,19 @@
 
 <section class="row">
     <div class="strip-inner-wrapper">
-        <h2>Why use Ubuntu Core?</h2>
         <div class="twelve-col equal-height">
-            <div class="seven-col equal-height__item">
+            <div class="six-col equal-height__item">
+                <h2>Why use Ubuntu Core?</h2>
                 <p>Ubuntu Core uses the same kernel, libraries and system software as classic Ubuntu.  You can develop snaps on your Ubuntu PC just like any other application. The difference is that it&rsquo;s been built for the Internet of Things.</p>
             </div>
-            <div class="five-col last-col equal-height__item equal-height__align-vertically not-for-small">
-                <img src="{{ ASSET_SERVER_URL }}e5202df6-ubuntu-core_black-orange_hex+copy.svg" alt="" />        
+            <div class="six-col last-col equal-height__item equal-height__align-vertically align-center not-for-small">
+                <img src="{{ ASSET_SERVER_URL }}5051e6e5-core_logo.svg" alt="" width="300" />
            </div>
             <div class="align-center five-col for-small no-margin-bottom">
-                <img src="{{ ASSET_SERVER_URL }}e5202df6-ubuntu-core_black-orange_hex+copy.svg" alt="" width="280" />        
+                <img src="{{ ASSET_SERVER_URL }}5051e6e5-core_logo.svg" alt="" width="280" />
            </div>
         </div>
-        
+
         <ul class="no-bullets twelve-col" style="padding-top:2em;">
             <li class="three-col">
                 <h3>Secure by default</h3>
@@ -100,7 +100,7 @@
             <h2>Features</h2>
             <p>Ubuntu Core is different from classic Ubuntu distributions. It is purposely lightweight and transactionally updated system, with security at its heart. The fundamental unit is the &ldquo;snap&rdquo; &mdash; a self contained, isolated and protected bit of code that performs a well-defined set of functions.  Even the kernel and core are snaps.</p>
         </div>
-        
+
         <div class="twelve-col not-for-small align-center" style="padding-top: 2em;">
             <div class="six-col">
                 <h4 class="six-col">Classic Ubuntu 16.04</h4>
@@ -110,7 +110,7 @@
             </div>
             <img src="{{ ASSET_SERVER_URL }}c34c1d3a-Ubuntu+Classic+vs+Core+-+Desktop+%28label%29+%281%29.svg" alt="" />
         </div>
-        
+
         <div class="align-center twelve-col for-small equal-height--vertical-divider" style="padding-top: 2em;">
             <div class="align-center six-col equal-height--vertical-divider__item">
                 <h3 class="six-col">Classic Ubuntu 16.04</h3>
@@ -133,7 +133,7 @@
             </div>
         </div>
     </div>
-</section>     
+</section>
 
 <section class="row strip-light">
     <div class="strip-inner-wrapper equal-height">


### PR DESCRIPTION
## Done

Updated the "Why use..." row on /core

## QA

 - Go to /core
 - View the "Why use..." row
 - Check that it looks better and works in all viewports
 - Rejoice