### PR TITLE
Added copy to iot robotics page and other slight markup tweaks

### DIFF
--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -34,7 +34,7 @@ feature amazing apps for advanced industrial intelligence.</p>
 </section>
 
 <!-- partners -->
-<section class="row strip-light">
+<section class="row strip-light no-border">
     <div class="strip-inner-wrapper">
         <div class="twelve-col">
             <h2 class="muted-heading">Join the robotics trailblazers on Ubuntu</h2>
@@ -83,7 +83,7 @@ feature amazing apps for advanced industrial intelligence.</p>
     </div>
 </section>
 
-<section class="row no-border">
+<section class="row">
     <div class="strip-inner-wrapper">
         <ul class="grid-list twelve-col no-bullets">
             <li class="grid-list__item six-col">

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -116,7 +116,11 @@ feature amazing apps for advanced industrial intelligence.</p>
 
 <section class="row strip-light no-border">
     <div class="strip-inner-wrapper">
-        <h2>Ubuntu runs on the robotic platforms that matter</h2>
+        <div class="twelve-col">
+            <h2>Ubuntu runs on the robotic platforms that matter</h2>
+            <p>Want to run Ubuntu Core on your hardware or write apps for an IoT device?</p>
+            <p><a class="external"  href="https://developer.ubuntu.com/en/snappy/?utm_campaign=device-fy17-iot-vertical-robotics-webpage&utm_medium=partnerhardwarelink&utm_source=ubunturobotics">Learn more</a></p>
+        </div>
         <ul class="grid-list twelve-col no-bullets">
             <li class="grid-list__item four-col">
                 <div class="grid-list__description align-center four-col">
@@ -155,14 +159,11 @@ feature amazing apps for advanced industrial intelligence.</p>
                 </div>
             </li>
         </ul>
-        <div class="eight-col">
-            <p><a class="external"  href="https://developer.ubuntu.com/en/snappy/?utm_campaign=device-fy17-iot-vertical-robotics-webpage&utm_medium=partnerhardwarelink&utm_source=ubunturobotics">Learn more</a></p>
-        </div>
     </div>
 </section>
 
 
-<section class="row row-cool-grey no-border-bottom row--contactus">
+<section class="row row-cool-grey no-border row--contactus">
     <div class="strip-inner-wrapper equal-height">
         <div class="three-col equal-height__item equal-height__align-vertically">
             <img src="{{ ASSET_SERVER_URL }}04927a56-robot_2px-white.svg" alt="robots are cool ;-)" class="not-for-small"/>


### PR DESCRIPTION
## Done

 - Added copy to the "...platforms that matter" row
 - Moved link up in the same row
 - Fixed the contact row's no-border class

## QA

 - Go to /internet-of-things/robotics
 - See that the "...platforms that matter" row has text and looks pretty
 - See that the "Will your next robot run on Ubuntu?" has no bottom border
 - Do a little happy dance

[Copy doc](https://docs.google.com/document/d/1g8XpVzDkAdFETrfZvOf5Q6WlYwHCBYQ8Y6TgTlyTEYc/edit#)