### PR TITLE
made drone image small on robotics page to make page weight lower

### DIFF
--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -155,7 +155,7 @@ feature amazing apps for advanced industrial intelligence.</p>
             <li class="grid-list__item four-col align-center  last-row last-col">
                 <div class="grid-list__description four-col">
                     <img class="robot_logo" src="{{ ASSET_SERVER_URL }}ba366bb7-aerolion-logo.png?h=50" alt="Aerolion" />
-                    <img class="robot_product" src="{{ ASSET_SERVER_URL }}3dbccdce-Aerolion_drone.png??w=250" alt="" />
+                    <img class="robot_product" src="{{ ASSET_SERVER_URL }}3dbccdce-Aerolion_drone.png?w=250" alt="" />
                 </div>
             </li>
         </ul>


### PR DESCRIPTION
## Done

Made a large image on /internet-of-things/robotics smaller by fixing the query string.

## QA

Go to /internet-of-things/robotics and see that the drong image under ALT (bottom left) now has a correctly formatted width-limiting query string, making the image loaded smaller.
