### PR TITLE
add japanese AU service description and tidied up the UA indentation

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description-ja.html
+++ b/templates/legal/ubuntu-advantage/service-description-ja.html
@@ -1,0 +1,845 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Ubuntu Advantage service description{% endblock %}
+
+{% block second_level_nav_items %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Legal" subsection_title="Ubuntu Advantage" page_title="Service description" %}
+{% endblock second_level_nav_items %}
+
+{% block content %}
+<div class="row row-hero no-border" id="service-description">
+    <div class="eight-col">
+
+        <h1>Ubuntu Advantageサービス記述書</h1>
+
+        <p class="intro">2016年10月2日より有効</p>
+
+        <h2 id="service-description-overview">1. 目次</h2>
+
+        <ol class="numbered">
+            <li><span class="number">1.1</span> 本書は以下のサービスを定義します。Canonicalは、本書に定義の通り、顧客契約の対象のサービスのみを提供します。</li>
+            <li><span class="number">1.2</span> プライマリーサービス：
+                <ul>
+                    <li>Ubuntu Advantage OpenStack Cloud Region</li>
+                    <li>Ubuntu Advantage Server (Essential/Standard/Advanced)</li>
+                    <li>Ubuntu Advantage Virtual Guest (Standard/Advanced)</li>
+                    <li>Ubuntu Advantage Ceph Storage</li>
+                    <li>Ubuntu Advantage Swift Storage</li>
+                    <li>Ubuntu Advantage MAAS (Standard/Advanced)</li>
+                    <li>Ubuntu Advantage Switch</li>
+                    <li>Ubuntu Advantage Desktop</li>
+                </ul>
+            </li>
+            <li><span class="number">1.3</span> アドオンサービス：
+                <ul>
+                    <li>Landscape Seats</li>
+                    <li>Technical Account Manager</li>
+                    <li>Dedicated Services Engineer</li>
+                    <li>Landscape On Premises</li>
+                </ul>
+            </li>
+        </ol>
+
+        <h2 id="ua-support-scope">2. サポート範囲</h2>
+        <p>各サービス製品には、Canonicalのナレッジベースおよび本書の範囲内の下記のサポートへのアクセスが含まれます。ただし<a href="#appendix-1">サポート範囲文書</a>に記載の例外に従います。</p>
+        <ol class="numbered">
+            <li id="support-scope-releases"><span class="number">2.1</span> リリース
+                <ul>
+                    <li>Canonicalは、プロジェクトのライフサイクル中に公式ソースを使用してインストールされたUbuntuの全標準リリースのインストール、設定、保守、および管理に関するサポートを提供します。Ubuntuのバージョン別ライフサイクルについては、こちらをご覧ください：<a href="/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a>。</li>
+                </ul>
+            </li>
+            <li id="support-scope-hardware"><span class="number">2.2</span> ハードウェア
+                <ul>
+                    <li>Ubuntu認定ハードウェアは、当社の広範なテストおよびレビュープロセスに合格しています。Ubuntu認定プロセスの詳細および認定ハードウェアの一覧については、Ubuntu認定ページをご覧ください： <a href="https://certification.ubuntu.com">www.ubuntu.com/certification</a>。本サービスは、顧客の認定ハードウェアのみに適用されます。認定されていないハードウェアのサービスを顧客から依頼された場合、Canonicalはサポートサービスを提供するために合理的な努力を払いますが、本サービス記述書に記載された義務に従わない場合があります。</li>
+                </ul>
+            </li>
+            <li id="support-scope-packages"><span class="number">2.3</span> パッケージ
+                <ol class="numbered">
+                    <li><span class="number">2.3.1</span> サービスは、Ubuntu MainリポジトリにあるパッケージおよびUniverse RepositoryにあるCanonical所有のパッケージのみに適用されます。ただし、(i) 「提案」および「バックポート」リポジトリポケット、および (ii) 該当するサポート範囲文書に記載された除外事項は除きます。<br />
+                    Universe Repositoryのサポート対象パッケージには、Jujuパッケージ、MAASパッケージ、nova-conductorパッケージ、およびこれらのパッケージと関連して使用される依存パッケージが含まれます。</li>
+                    <li><span class="number">2.3.2</span> Ubuntuアーカイブにあるバージョンから変更されているパッケージはサポート対象外です。</li>
+                </ol>
+            </li>
+            <li id="support-scope-kernels"><span class="number">2.4</span> カーネル
+                <ol class="numbered">
+                    <li><span class="number">2.4.1</span> Ubuntuの長期サポート (LTS） バージョンのリリースで最初に提供されたカーネルは、LTSの全ライフサイクルにおいてサポートされます。</li>
+                    <li><span class="number">2.4.2</span> ハードウェアイネーブルメント (HWE) カーネルは、LTSリリースでより新しいハードウェアに対するサポートを提供し、非LTS Ubuntuリリースと共にリリースされます。HWEカーネルは、次のLTSポイントリリースまでサポートされます。</li>
+                    <li><span class="number">2.4.3</span> カーネルのサポートに関する詳細についてはこちらをご覧ください。 <a href="/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a></li>
+                </ol>
+            </li>
+            <li id="support-scope-landscape"><span class="number">2.5</span> Landscape
+                <ol class="numbered">
+                    <li><span class="number">2.5.1</span> Landscape On Premises (購入した場合) を含むすべてのLandscape製品は完全にサポートされます。</li>
+                    <li><span class="number">2.5.2</span> 別途記述がない限り、Landscape SaaSシステム管理ツールへのアクセスはすべてのサポート製品に含まれています。</li>
+                </ol>
+            </li>
+            <li id="support-scope-openstack"><span class="number">2.6</span> OpenStack
+                <ol class="numbered">
+                    <li><span class="number">2.6.1</span> 本セクションは、OpenStackのサポートのために購入されたサービスに適用されます。OpenStackサポートが含まれるサービスは以下の通りです：
+                        <ul>
+                            <li>Ubuntu Advantage Server Standard</li>
+                            <li>Ubuntu Advantage Server Advanced</li>
+                            <li>Ubuntu Advantage OpenStack Cloud Region</li>
+                        </ul>
+                    </li>
+                    <li><span class="number">2.6.2</span> OpenStackサポートには、サポート対象ノードが5つ以上ある環境が必要です。</li>
+                    <li><span class="number">2.6.3</span> Canonical Architectureとは以下を指します：
+                        <ul>
+                            <li>Juju、MAAS、および公式チャームリリースを使用してCanonicalとの契約に基づいてデプロイされたUbuntu OpenStackインストール。Canonicalとの契約に基づいてデプロイした結果、チャームのカスタマイズが必要になった場合、カスタマイズの有効期間はそのカスタマイズを含むチャームの公式リリース後90日間です。</li>
+                            <li>CanonicalのOpenStack Autopilotを使用したUbuntu OpenStackのデプロイメント。</li>
+                        </ul>
+                    </li>
+                    <li><span class="number">2.6.4</span> Canonical Architectureを使用しないでデプロイされたインストールについては、サポートはUbuntu OpenStackパッケージ自体のバグに限定されます。また、OpenStackインストールのデプロイ、設定、または問題最適化に関するサポートは含まれません。</li>
+                    <li><span class="number">2.6.5</span> デプロイされたノード1つにつき合計で最大3TBの使用可能ストレージに対するサポート。この許容量は、Ubuntu Advantage Ceph、Ubuntu Advantage Swift、またはこれらの組み合わせに対して使用できます。</li>
+                    <li><span class="number">2.6.6</span> サポート対象のOpenStackバージョン:
+                        <ul>
+                            <li>Ubuntuの長期サポート (LTS) バージョンのリリースで最初に提供されたOpenStackのバージョンは、そのUbuntuバージョンの全ライフサイクルにおいてサポートされます。</li>
+                            <li>UbuntuのLTSバージョン後にリリースされたOpenStackのリリースは、Ubuntu Cloud Archiveで公開されます。Ubuntu Cloud Archiveにある各OpenStackリリースは、該当するOpenStackバージョンを含むUbuntuバージョンのリリース日から最低18ヶ月間、Ubuntu LTSバージョンでサポートされます。</li>
+                            <li>OpenStackリリースのサポートスケジュールについては <a href="/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a> をご覧ください。</li>
+                        </ul>
+                    </li>
+                </ol>
+            </li>
+            <li id="charms"><span class="number">2.7</span> チャーム
+                <ol class="numbered">
+                    <li><span class="number">2.7.1</span> 本セクションは、OpenStackのサポートのために購入されたサービスに適用されます。</li>
+                    <li><span class="number">2.7.2</span> Canonicalは、Canonicalの参照アーキテクチャを使用してデプロイされたOpenStackクラウドを実行するために必要なチャームに対するサポートを提供します。</li>
+                    <li><span class="number">2.7.3</span> 各チャームバージョンは、リリース日から1年間サポートされます。</li>
+                    <li><span class="number">2.7.4</span> チャームストアにあるサポート対象バージョンから変更されているチャームはサポートされません。</li>
+                </ol>
+            </li>
+        </ol>
+    </div>
+
+    <div class="box four-col last-col not-for-small">
+        <h3>Contents</h3>
+        <ol class="nested-counter">
+            <li class="nested-counter__item"><a href="#service-description-overview">概要&nbsp;&rsaquo;</a></li>
+            <li class="nested-counter__item">
+                <a href="#ua-support-scope">サポート範囲&nbsp;&rsaquo;</a>
+                <ol class="nested-counter">
+                    <li class="nested-counter__item"><a href="#support-scope-releases">リリース&nbsp;&rsaquo;</a></li>
+                    <li class="nested-counter__item"><a href="#support-scope-hardware">ハードウェア&nbsp;&rsaquo;</a></li>
+                    <li class="nested-counter__item"><a href="#support-scope-packages">パッケージ&nbsp;&rsaquo;</a></li>
+                    <li class="nested-counter__item"><a href="#support-scope-kernels">カーネル&nbsp;&rsaquo;</a></li>
+                    <li class="nested-counter__item"><a href="#support-scope-landscape">Landscape&nbsp;&rsaquo;</a></li>
+                    <li class="nested-counter__item"><a href="#support-scope-openstack">OpenStack&nbsp;&rsaquo;</a></li>
+                    <li class="nested-counter__item"><a href="#charms">チャーム&nbsp;&rsaquo;</a></li>
+                </ol>
+            </li>
+            <li class="nested-counter__item"><a href="#response-times">応答時間&nbsp;&rsaquo;</a></li>
+            <li class="nested-counter__item"><a href="#support-process">サポートプロセス&nbsp;&rsaquo;</a></li>
+            <li class="nested-counter__item"><a href="#assurance">保証&nbsp;&rsaquo;</a></li>
+        </ol>
+
+        <h3><a href="#appendix-1">付録1 - サポート範囲&nbsp;&rsaquo;</a></h3>
+        <ol>
+            <li><a href="#ua-openstack-cloud-region">OpenStack Cloud Region&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-server">Server&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-virtual-guest">Virtual Guest&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-ceph-storage">Ceph Storage&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-swift-storage">Swift Storage&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-maas">MAAS&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-switch">Switch&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-desktop">Desktop&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-landscape-virtual-machines">仮想マシンのLandscapeエージェント&nbsp;&rsaquo;</a></li>
+            <li><a href="#tam">テクニカルアカウントマネージャー (TAM)&nbsp;&rsaquo;</a></li>
+            <li><a href="#dedicated-services-engineer">専任サービスエンジニア (DSE)&nbsp;&rsaquo;</a></li>
+            <li><a href="#landscape-on-premises">Landscape On Premises&nbsp;&rsaquo;</a></li>
+        </ol>
+
+        <h3><a href="#appendix-2">付録2 - サポートプロセス&nbsp;&rsaquo;</a></h3>
+        <ol>
+            <li><a href="#ua-support-service-initiation">サービス開始&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-support-submitting-support-requests">サポート要求の提出&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-support-severity-levels">サポートの重大度レベル&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-support-hotfixes">ホットフィックス&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-support-languages">サポートの言語&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-support-remote-sessions">リモートセッション&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-support-regions">サポート地域&nbsp;&rsaquo;</a></li>
+        </ol>
+
+        <h3><a href="#appendix-3">付録3 - マネジメントエスカレーション&nbsp;&rsaquo;</a></h3>
+    </div>
+
+    <div class="box four-col last-col">
+        <h3>英訳</h3>
+        <ul class="list">
+            <li class="last-item"><a href="/legal/ubuntu-advantage/service-description">Ubuntu Advantage service description&nbsp;›</a></li>
+        </ul>
+    </div>
+
+    <div class="eight-col">
+
+        <h2 id="response-times">3. 応答時間</h2>
+
+        <ol class="numbered">
+            <li><span class="number">3.1</span> Canonicalは、以下に規定する応答時間内に、該当するサービスレベルおよび重大度に基づき、顧客からのサポート要求に応答するための合理的な努力を払います。</li>
+            <li><span class="number">3.2</span> 「営業時間」および「営業日」は下表に定義されます。これらは祝日を除き、別の場所が合意されない限り、顧客の本社のある地域に基づきます。</li>
+        </ol>
+    </div>
+
+    <table class="twelve-col">
+        <caption>営業時間表</caption>
+        <thead>
+            <tr scope="row">
+                <th>サービス</th>
+                <th>営業時間</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Ubuntu Advantage Server Essential<br />
+                Ubuntu Advantage Desktop</td>
+                <td>月曜～金曜 9:00～17:00</td>
+            </tr>
+            <tr>
+                <td>Ubuntu Advantage Server Standard<br />
+                Ubuntu Advantage Virtual Guest Standard<br />
+                Ubuntu Advantage MAAS Standard</td>
+                <td>月曜～金曜 8:00～18:00</td>
+            </tr>
+            <tr>
+                <td>Ubuntu Advantage OpenStack Cloud Region<br />
+                Ubuntu Advantage Server Advanced<br />
+                Ubuntu Advantage Virtual Guest Advanced<br />
+                Ubuntu Advantage Ceph Storage<br />
+                Ubuntu Advantage Swift Storage<br />
+                Ubuntu Advantage MAAS Advanced<br />
+                Ubuntu Advantage Switch<br />
+                Landscape On Premises</td>
+                <td>月曜～金曜 8:00～18:00</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <table class="twelve-col">
+        <caption>応答時間表</caption>
+        <thead>
+            <tr scope="row">
+                <th>&nbsp;</th>
+                <th>重大度 <br />レベル1</th>
+                <th>重大度 <br />レベル2</th>
+                <th>重大度 <br />レベル3</th>
+                <th>重大度 <br />レベル4</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Ubuntu Advantage Desktop</td>
+                <td>2営業日</td>
+                <td>2営業日</td>
+                <td>2営業日</td>
+                <td>2営業日</td>
+            </tr>
+            <tr>
+                <td>Ubuntu Advantage Server Essential</td>
+                <td>1営業日</td>
+                <td>1営業日</td>
+                <td>2営業日</td>
+                <td>4営業日</td>
+            </tr>
+            <tr>
+                <td>Ubuntu Advantage Server Standard<br />
+                Ubuntu Advantage Virtual Guest Standard<br />
+                Ubuntu Advantage MAAS Standard</td>
+                <td>2営業時間</td>
+                <td>4営業時間</td>
+                <td>1営業日</td>
+                <td>2営業日</td>
+            </tr>
+            <tr>
+                <td>Ubuntu Advantage OpenStack Cloud Region<br />
+                Ubuntu Advantage Server Advanced<br />
+                Ubuntu Advantage Virtual Guest Advanced<br />
+                Ubuntu Advantage Ceph Storage<br />
+                Ubuntu Advantage Swift Storage<br />
+                Ubuntu Advantage MAAS Advanced<br />
+                Ubuntu Advantage Switch<br />
+                Landscape On Premises</td>
+                <td>1時間</td>
+                <td>4営業時間</td>
+                <td>6営業時間</td>
+                <td>1営業日</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="eight-col">
+        <h2 id="support-process">4. サポートプロセス</h2>
+        <p>Canonicalは、サポートケースを解決できるよう合理的な努力を払いますが、回避策、解決策、または解決時間は保証しません。</p>
+
+        <ol class="numbered">
+            <li><span class="number">4.1</span> Canonicalは、<a href="#appendix-2">サポートプロセスに従って</a>サービスを提供します。</li>
+            <li><span class="number">4.2</span> 顧客は、<a href="#appendix-3">エスカレーションプロセスに従って</a>サポート問題をエスカレーションできます。</li>
+        </ol>
+
+        <h2 id="assurance">5. 保証</h2>
+        <ol class="numbered">
+            <li><span class="number">5.1</span> 顧客は、利用規約に従って、Ubuntu保証プログラムに加入する権利を有します。Canonicalは、保証プログラムおよびその規約を定期的に更新することができます。現在のUbuntu保証プログラムおよびそのIP免責条項はUbuntu保証ページでご覧いただけます：<a href="/legal/ubuntu-advantage/assurance">www.ubuntu.com/legal/ubuntu-advantage/assurance</a>。</li>
+        </ol>
+    </div><!-- /.eight-col -->
+</div><!-- /.row -->
+
+<div class="row no-border" id="appendix-1">
+    <div class="eight-col">
+        <h2 id="ua-appendix-1_support-scope">付録1 - サポート範囲</h2>
+        <h3 id="ua-openstack-cloud-region">Ubuntu Advantage OpenStack Cloud Region</h3>
+        <p>定義：</p>
+
+        <ul>
+            <li>「OpenStack」とは、CanonicaによりUbuntuに配布されている「OpenStack」と呼ばれるクラウドコンピューティングソフトウェアを指します。</li>
+            <li>「リージョン」とは、専用APIエンドポイントを持つ個々のOpenStack環境を指し、通常、Identity (Keystone) サービスのみを他のリージョンと共有します。単一のデータセンターには必ず1つのOpenStackリージョンが含まれています。</li>
+            <li>「パブリッククラウド」とは、第三者がゲストインスタンスを作成/管理できるクラウド環境を指します。</li>
+            <li>「クラウドゲスト」とは、パブリッククラウドで実行されていないUbuntu Serverのインスタンスを指します。</li>
+        </ul>
+
+        <p>サポートは、1つのリージョン、および購入したUbuntu Advantage OpenStack Cloud Regionのサイズに基づく最大数のノードに限定されます。</p>
+
+        <p>追加でサービスに含まれるもの：</p>
+        <ul>
+            <li>OpenStackの実行に必要なすべてのパッケージに対するサポート。</li>
+            <li>クラウドゲスト向けUbuntu Advantage Server Advanced services。</li>
+            <li>Landscape On Premises</li>
+        </ul>
+
+        <p>サービスから除外されるもの：</p>
+
+        <ul>
+            <li>OpenStackデプロイメントの実行に必要でないワークロードに対するサポート。</li>
+            <li>Canonical Architectureを使用しないでデプロイされたデプロイメントに対するサポート。</li>
+            <li>クラウドゲスト以外のゲストインスタンスに対するサポート。</li>
+        </ul>
+
+        <h3 id="ua-server">Ubuntu Advantage Server</h3>
+
+        <p>それぞれのサービス (Essential、Standard、またはAdvanced) の範囲を以下に定めます。以下のアイテムは、別途規定されている場合を除き、Ubuntu Advantage Serverサービスの対象外です。</p>
+
+        <ul>
+            <li>Ceph</li>
+            <li>Swift</li>
+        </ul>
+
+
+        <h4>サービスの概要</h4>
+
+        <table>
+            <thead>
+                <tr>
+                    <th scope="col">内容</th>
+                    <th scope="col">Essential</th>
+                    <th scope="col">Standard</th>
+                    <th scope="col">Advanced</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td scope="row">24x7セルフサービスカスタマケアポータルおよびナレッジベース (<a href="#ua-support-scope">セクション2</a>を参照)</td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                </tr>
+                <tr>
+                    <td scope="row">Ubuntu Serverイメージのデフォルトパッケージに対する8x5チケットサポート (<a href="#response-times">セクション3</a>を参照)</td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                </tr>
+                <tr>
+                    <td scope="row">Landscape管理 (<a href="#support-scope-landscape">セクション2.5</a>を参照)</td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                </tr>
+                <tr>
+                    <td scope="row">Ubuntu法的保証プログラム (<a href="#assurance">セクション5</a>を参照)</td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                </tr>
+                <tr>
+                    <td scope="row">10x5 Ubuntu Main内のすべてのパッケージに対する電話およびチケットサポート (<a href="#response-times">セクション3</a>)を参照)、ただし<a href="#lxd-guest-support">このセクション</a>に記載されているものを除く</td>
+                    <td></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                </tr>
+                <tr>
+                    <td scope="row">無制限の<a href="#lxd-guest-support">Ubuntu LXD ゲストサポート</a></td>
+                    <td></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                </tr>
+                <tr>
+                    <td scope="row">24x7 Ubuntu main内のすべてのパッケージに対する電話およびチケットサポート (<a href="#response-times">セクション3</a>を参照)、およびバックポートおよびuniverse内のCanonical作成パッケージ。ただし<a href="#kvm-guest-support">このセクション</a>に記載されているものを除く</td>
+                    <td></td>
+                    <td></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                </tr>
+                <tr>
+                    <td scope="row">無制限の<a href="#kvm-guest-support">Ubuntu KVM ゲストサポート</a></td>
+                    <td></td>
+                    <td></td>
+                    <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
+                </tr>
+            </tbody>
+        </table>
+
+        <h4 id="service-offering-definitions">Essential</h4>
+
+        <p>サービスに含まれるもの：</p>
+
+        <ul>
+            <li>サーバー/クラウドイメージマニフェストにあるパッケージに対するサポート。</li>
+        </ul>
+
+        <p>サービスから除外されるもの：</p>
+
+        <ul>
+            <li>サーバー/クラウドイメージマニフェストにないパッケージに対するサポート。</li>
+            <li>サーバー/クラウドイメージから提供されたパッケージに見つかったバグ以外の問題に対するサポート。</li>
+            <li>電話サポートへのアクセス。</li>
+        </ul>
+
+        <h4 id="lxd-guest-support">Standard</h4>
+
+        <p>サービスに含まれるもの：</p>
+
+        <ul>
+            <li>無制限の数のUbuntu LXDゲストに対するUbuntu Advantage Virtual Guest Standardサポート。</li>
+        </ul>
+
+        <p>サービスから除外されるもの：</p>
+
+        <ul>
+            <li>KVMゲストに対するUbuntu Advantageサポート。</li>
+            <li>Ubuntu LXDゲストに対するLandscapeシステム管理ツールへのアクセス。ただしLandscape On PremisesのLandscape Seatsでカバーされているものを除く。</li>
+        </ul>
+
+        <h4 id="kvm-guest-support">Advanced</h4>
+
+        <p>サービスに含まれるもの：</p>
+
+        <ul>
+            <li>無限の数のUbuntu LXDおよびUbuntu KVMゲストに対するUbuntu Advantage Virtual Guest Standardサポート。</li>
+        </ul>
+
+        <p>サービスから除外されるもの：</p>
+
+        <ul>
+            <li>Ubuntu LXDまたはUbuntu KVMゲストゲストに対するLandscapeシステム管理ツールへのアクセス。ただしLandscape On PremisesのLandscape Seatsでカバーされているものを除く。</li>
+        </ul>
+
+        <h3 id="ua-virtual-guest">Ubuntu Advantage Virtual Guest</h3>
+
+        <ul>
+            <li>Ubuntu Serverに対してサービスが提供されるのは、物理ホスト上の仮想化された環境またはUbuntuの認定パブリッククラウドパートナーの環境でインストールおよび実行されている場合です。認定パブリッククラウドパートナーについては、Ubuntuパートナー一覧をご覧ください：<a href="http://partners.ubuntu.com/find-a-partner">partners.ubuntu.com/find-a-partner</a></li>
+            <li>サービス除外は、該当するUbuntu Advantage Serverサービスのサービス除外と同じです。</li>
+        </ul>
+
+        <h3 id="ua-ceph-storage">Ubuntu Advantage Ceph Storage</h3>
+
+        <p>定義：</p>
+
+        <ul>
+            <li>「クラスタ」とは、単一の物理データセンター内にある単一のCephインストールを指します。</li>
+        </ul>
+
+        <p>サポートは、すべてのストレージプールのCephに格納されている合計データ数 (ギガバイト) によって評価されます。空き領域とすべての複製およびイレージャーコーディングオーバーヘッドは除外されます。</p>
+
+        <p>Jujuを使用してCephダッシュボードが環境にデプロイされている必要があります。</p>
+
+        <p>無制限のストレージ容量に対するUbuntu Advantage Ceph Storageを購入した顧客は、単一クラスタでのサポートに制限されます。</p>
+
+        <p>追加でサービスに含まれるもの：</p>
+
+        <ul>
+            <li>Cephデプロイメントの実行に必要なすべてのパッケージに対するサポート。</li>
+            <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサポート。これには、Cephモニターなど予備 (ストレージ以外の) ノードが含まれます。</li>
+        </ul>
+
+        <p>サービスから除外されるもの：</p>
+
+        <ul>
+            <li>Cephプロイメントの実行に必要でないワークロードに対するサポート。</li>
+        </ul>
+
+        <h3 id="ua-swift-storage">Ubuntu Advantage Swift Storage</h3>
+
+        <p>定義：</p>
+
+        <ul>
+            <li>「クラスタ」とは、単一の物理データセンター内にある単一のSwiftインストールを指します。</li>
+        </ul>
+
+        <p>サポートは、すべてのストレージプールのSwiftに格納されている合計データ数 (ギガバイト) によって評価されます。空き領域とすべての複製およびイレージャーコーディングオーバーヘッドは除外されます。</p>
+
+        <p>無制限のストレージ容量に対するUbuntu Advantage Swift Storageを購入した顧客は、単一クラスタでのサポートに制限されます。</p>
+
+        <p>追加でサービスに含まれるもの：</p>
+
+        <ul>
+            <li>Swiftデプロイメントの実行に必要なすべてのパッケージに対するサポート。</li>
+            <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサポート。これには、Swiftモニターなど予備 (ストレージ以外の) ノードが含まれます。</li>
+        </ul>
+
+        <p>サービスから除外されるもの：</p>
+
+        <ul>
+            <li>Swiftプロイメントの実行に必要でないワークロードに対するサポート。</li>
+        </ul>
+
+        <h3 id="ua-maas">Ubuntu Advantage MAAS</h3>
+
+        <p>サービスに含まれるもの：</p>
+
+        <ul>
+            <li>文書化されたMAASデプロイメントアーキテクチャに従ってMAAS環境をホストするために必要なすべてのサーバーに対するサポート。</li>
+            <li>MAASの実行に必要なすべてのパッケージに対するサポート。</li>
+            <li>Canonical提供のオペレーティングシステムイメージを使用してマシンを起動できるようにするためのサポート。</li>
+            <li>Canonical提供でない認定オペレーティングシステムイメージをMAASイメージに変換するために必要なツールのサポート。</li>
+            <li>標準の高可用性MAAS構成を適切に実装するために必要なツールのサポート。</li>
+        </ul>
+
+        <p>サービスから除外されるもの：</p>
+
+        <ul>
+            <li>MAASデプロイメントの実行に必要でないワークロード、パッケージ、およびサービスコンポーネントに対するサポート。</li>
+            <li>MAASを使用してデプロイされたノードのサポート。</li>
+            <li>MAASデプロイメントの設計および実装詳細のサポート。</li>
+        </ul>
+
+        <p>サポートされるMAASバージョン：</p>
+
+        <ul>
+            <li>MAASバージョンは、Ubuntuアーカイブにリリースされた日付から1年間、UbuntuのLTSバージョンでサポートされます。</li>
+        </ul>
+
+        <h3 id="ua-switch">Ubuntu Advantage Switch</h3>
+
+        <p>定義：</p>
+
+        <ul>
+            <li>「ホワイトボックススイッチ」とは、ODMメーカーが製造し、ベンダーがラベル添付および販売を行うx86 Broadcom ASICベースのスイッチを指します。</li>
+            <li>「BCOS」とは、ホワイトボックススイッチからのフル装備のレイヤー2およびレイヤー3ネットワーキングソフトウェアのUbuntu最適化バージョンです。</li>
+        </ul>
+
+        <p>含まれるサービス：</p>
+
+        <ul>
+            <li>BCOSの実行に必要な特定のUbuntuバージョンのサポート。</li>
+            <li>BCOSソフトウェアのサポート。</li>
+        </ul>
+
+        <p>含まれないサービス：</p>
+
+        <ul>
+            <li>BCOSの実行に必要でないワークロードに対するサポート。</li>
+            <li>BCOSソフトウェアと共に提供されるバージョン以外のカーネルのサポート。</li>
+            <li>物理ハードウェアのサポート。ハードウェアサポートはベンダーによって提供されます。</li>
+            <li>Landscape SaaSおよびLandscape On Premises</li>
+        </ul>
+
+        <h3 id="ua-desktop">Ubuntu Advantage Desktop</h3>
+
+        <p>含まれないサービス：</p>
+
+        <ul>
+            <li>仮想マシン</li>
+            <li>マシンコンテナ</li>
+            <li>アプリケーションコンテナ</li>
+            <li>デュアルブート (他のオペレーティングシステムとの共存)</li>
+            <li>開発者ツール</li>
+            <li>Ubuntuでの使用が認定されていない周辺機器</li>
+        </ul>
+
+        <h3 id="ua-landscape-virtual-machines">Landscape Seats</h3>
+
+        <p>定義：</p>
+
+        <ul>
+            <li>「Seats」とは、仮想マシンをLandscape SaaSまたはLandscape On Premisesに登録できる能力を指します。</li>
+            <li>「仮想マシン」とは、仮想化された環境にインストールされ、そこで実行されているUbuntu Serverを指します。</li>
+        </ul>
+
+        <p>サービスに含まれるもの：</p>
+
+        <ul>
+            <li>Ubuntu Advantageサービス対象のシステムで実行されているSeats。</li>
+        </ul>
+
+        <p>サービスから除外されるもの：</p>
+
+        <ul>
+            <li>Landscapeクライアントのインストールおよび実行に必要なパッケージのサポートを超えるサポート。</li>
+        </ul>
+
+        <h3 id="tam">テクニカルアカウントマネージャー (TAM)</h3>
+
+        <p>定義:</p>
+
+        <ul>
+            <li>「TAM」とは、顧客の従業員や経営陣と直接連携するためにリモートで作業を行うCanonicalサポートエンジニアを指します。</li>
+        </ul>
+
+        <p>Canonicalは、サポートサービスの向上のためにTAMによるサービスを行います。TAMはサービス期間中、以下のサービスを週あたり最大10時間行います。</p>
+
+        <ul>
+            <li>該当するUbuntu Advantageサービスの対象のプラットフォームおよび構成に関するサポートおよびベストプラクティスアドバイスを提供します。</li>
+            <li>2週に1度、互いに合意した回数、レビューコールに参加し、顧客が抱える運用上の問題に対応します。</li>
+            <li>TSANetまたはCanonicalの直接パートナーシップ (該当する場合) を通じてマルチベンダー問題の調整を行います。根本的な原因が特定できたら、TAMは、そのサブシステムのベンダーと共に通常のサポートプロセスを通じてケースの解決に努めます。</li>
+        </ul>
+
+        <p>Canonicalは四半期に1度、顧客とのサービスレビューミーティングを開き、サービスのパフォーマンスを評価し、改善領域を特定します。</p>
+
+        <p>TAMは顧客のサイトを年に1度訪問し、オンサイトテクニカルレビューを行います。</p>
+
+        <p>TAMは、TAMの稼働時間中、サポートケースに対応します。稼働時間外は、Ubuntu Advantageサポートプロセスに従ってサポートが提供されます。</p>
+
+        <h3 id="dedicated-services-engineer">専任サービスエンジニア (DSE)</h3>
+
+        <p>定義：</p>
+
+        <ul>
+            <li>「DSE」とは、単一の顧客のためにリモートでフルタイムで作業を行う専任のCanonicalサポートエンジニアを指します。</li>
+        </ul>
+
+        <p>Canonicalは、サポートサービスの向上のためにDSEによるサービスを行います。DSEはサービス期間中、現地営業時間内に以下のサービスを週あたり最大40時間行います (Canonicalの休暇に関する方針によります)。</p>
+
+        <ul>
+            <li>該当するUbuntu Advantageサービスの対象のプラットフォームおよび構成に関するサポートおよびベストプラクティスアドバイスを提供します。</li>
+            <li>DSEは、担当する顧客部門からのすべてのサポート要求を最初に受け付ける窓口となります。</li>
+            <li>Canonicalの標準サポート応答定義および顧客のニーズに従い、サポートのエスカレーションおよび優先順位付けを管理します。</li>
+            <li>定期レビューコールに参加し、顧客が抱える運用上の問題に対応します。</li>
+            <li>TSANetまたはCanonicalの直接パートナーシップ (該当する場合) を通じてマルチベンダー問題の調整を行います。根本的な原因が特定できたら、DSEは、そのサブシステムのベンダーと共に通常のサポートプロセスを通じてケースの解決に努めます。</li>
+            <li>適切なCanonical社内トレーニングおよび開発活動に参加します (直接参加またはリモート)。</li>
+        </ul>
+
+        <p>Canonicalは四半期に1度、顧客とのサービスレビューミーティングを開き、サービスのパフォーマンスを評価し、改善領域を特定します。</p>
+        <p>DSEは、DSEの稼働時間中、サポートケースに対応します。営業時間外は、Ubuntu Advantageサポートプロセスに従ってサポートが提供されます。</p>
+
+
+        <h3 id="landscape-on-premises">Landscape On Premises</h3>
+
+        <p>定義：</p>
+
+        <ul>
+            <li>「Landscape On Premises」とは、顧客のハードウェアにインストールされたCanonicalのLandscapeシステム管理ソフトウェアを指します。</li>
+        </ul>
+
+        <p>サービスに含まれるもの：</p>
+
+        <ul>
+            <li>Landscape On Premisesのインスタンスを1つダウンロードおよびインストールするためのライセンス。</li>
+            <li>Ubuntu Advantageサービス購入の対象となった (物理または仮想) マシンに対してLandscape On Premises管理およびモニタリングサービスを使用する能力。</li>
+        </ul>
+
+        <p>デプロイ方式：</p>
+
+        <ul>
+            <li>「クイックスタート」インストール方式を使用してインストールされている場合、Landscape On Premisesをインストールするマシンに対するサポートが含まれます。</li>
+            <li>マニュアルインストール方式を使用してインストールされている場合、Landscape On Premisesをインストールする最大2台のサーバーに対するサポートが含まれます。</li>
+            <li>Jujuを使用してデプロイする場合、「高密度デプロイ」方式がサポートされます。</li>
+        </ul>
+
+        <p>サービスから除外されるもの：</p>
+
+        <ul>
+            <li>Landscape On Premisesパッケージのサポート以上のサポート。</li>
+        </ul>
+
+        <p>サポートされるLandscape On Premisesバージョン：</p>
+
+        <ul>
+            <li>Landscape On Premisesの各リリースは、リリース日から1年間サポートされます。</li>
+        </ul>
+        <!-- / Appendix 1 -->
+    </div><!-- /.eight-col -->
+
+    <div class="eight-col">
+        <p><a href="#service-description">先頭へ戻る</a></p>
+    </div>
+</div><!-- /.row -->
+
+<div class="row no-border no-border" id="appendix-2">
+    <div class="eight-col">
+
+        <h2 id="ua-support-process">付録2 - Ubuntu Advantageサポートプロセス</h2>
+
+        <h3 id="ua-support-service-initiation">1. サービス開始</h3>
+
+        <ol class="numbered">
+            <li><span class="number">1.1</span> サービス開始時、Canonicalは、Landscape、サポートポータル、およびオンラインナレッジベースへのアクセス権を1人の技術担当者に付与します。</li>
+            <li><span class="number">1.2</span> この初期技術担当者を通じて、顧客は、下表の通り、サポート対象のシステム数に基づいてCanonicalとの接点となる技術担当者を選択できます。これらの技術担当者はポータルをサポートするためのクレデンシャルを持ち、サポート要求の主要窓口となります。</li>
+        </ol>
+
+    </div>
+
+    <table class="eight-col">
+        <caption>サポート対象のマシンの表</caption>
+        <thead>
+            <tr>
+                <th>Ubuntu Advantageサポート対象のマシン数</th>
+                <th>技術担当者</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>1-20</td>
+                <td>2</td>
+            </tr>
+            <tr>
+                <td>21-50</td>
+                <td>3</td>
+            </tr>
+            <tr>
+                <td>51-250</td>
+                <td>6</td>
+            </tr>
+            <tr>
+                <td>251-1000</td>
+                <td>9</td>
+            </tr>
+            <tr>
+                <td>1001-5000</td>
+                <td>12</td>
+            </tr>
+            <tr>
+                <td>5001+</td>
+                <td>15</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="eight-col">
+        <ol class="numbered">
+            <li><span class="number">1.3</span> 顧客は、サポートポータル経由でサポート要求を提出することにより、指定された技術担当者をいつでも変更できます。</li>
+        </ol>
+
+        <h3 id="ua-support-submitting-support-requests">2. サポート要求の提出</h3>
+
+        <ol class="numbered">
+            <li><span class="number">2.1</span> 顧客アカウントがサポートポータルに作成されると、顧客はサポート要求をオープンできます。</li>
+            <li><span class="number">2.2</span> 別途記載がない限り、顧客は、サポートポータル経由で、または電話でサポートチームに連絡することにより、サポートケースを提出できます。</li>
+            <li><span class="number">2.3</span> サポートケースは、単一の独立した問題または要求である必要があります。</li>
+            <li><span class="number">2.4</span> ケースにはチケット番号が割り当てられ、自動応答が返されます。品質保証のため、メールや電話などケースに直接入力されない連絡はすべてタイムスタンプ付きでケースに記録されます。</li>
+            <li id="ua-support-submitting-support-requests-2-5"><span class="number">2.5</span> 顧客がケースを報告する場合には、Canonicalが適切なサービスレベルを決定できるよう、顧客は影響に関する陳述書を提供する必要があります。複数のサポートケースを同時に抱えている顧客は、ビジネスへの影響の重大度に従ってケースに優先順位を付けるよう求められる場合があります。</li>
+            <li><span class="number">2.6</span> ケースの解決中、顧客はCanonicalが要求したすべての情報を提供することが期待されます。</li>
+            <li><span class="number">2.7</span> 各ケースのレコードは、Canonicalのサポートポータル内に保持されます。顧客は現行のすべてのケースの追跡と応答が可能で、これまでのケースをレビューできます。</li>
+        </ol>
+
+        <h3 id="ua-support-severity-levels">3. サポートの重大度レベル</h3>
+
+        <ol class="numbered">
+            <li><span class="number">3.1</span> サポート要求がオープンすると、Canonicalのサポートエンジニアがケース情報を検証して重大度レベルを決定し、顧客と共にケースの緊急性を評価します。</li>
+            <li><span class="number">3.2</span> 応答時間は、該当するサービスのサービス記述書に規定された通りです。</li>
+            <li><span class="number">3.3</span> 重大度レベルの決定に際して、Canonicalのサポートチームは下記の定義を使用します。</li>
+        </ol>
+    </div>
+
+    <table class="twelve-col">
+        <tbody>
+            <tr>
+                <th style="width: 250px;"><strong>重大度レベル1</strong><br />
+                コア機能が利用できない</th>
+                <td>Canonicalは、購入されたサービスレベルに従って、適切なサポートエンジニアまたは開発エンジニアを介して回避策または恒久的な解決策を提供するよう継続的努力します。コア機能が利用可能になった時点で、重大度レベルは新しい適切なサービスレベルに下がります。</td>
+            </tr>
+
+            <tr>
+                <th><strong>重大度レベル2</strong><br />
+                コア機能が著しく低下している</th>
+                <td>Canonicalは、該当する営業時間中、回避策または恒久的な解決策を顧客に提供するよう、一丸となって取り組みます。コア機能の著しい低下が解消された時点で、重大度レベルはレベル3に下がります。</td>
+            </tr>
+
+            <tr>
+                <th><strong>重大度レベル3</strong><br />
+                標準のサポート要求</th>
+                <td>Canonicalは、該当する営業時間中、回避策または恒久的な解決策をできるだけ早く顧客に提供するよう、上位の重大度レベルのケースとのバランスを取りつつ合理な努力を払います。回避策が提供された場合、Canonicalのサポートエンジニアは、ケースに対する恒久的な解決策を見つけるよう引き続き努力します。</td>
+            </tr>
+
+            <tr>
+                <th><strong>重大度レベル4</strong><br />
+                緊急性のない要求</th>
+                <td>レベル4の要求には、表面上の問題、情報の要求、機能要求などがあります。Canonicalは、いかなる機能要求についても、タイムラインまたは採用の保証は提供しません。Canonicalは、各レベル4ケースをレビューし、それが将来のリリースで検討すべき製品拡張であるか、現行リリースで修正すべき問題であるか、あるいは将来のリリースで修正すべき問題であるかを決定します。情報要求については、サポート範囲の時間中、合理的なレベルの努力でレビューし、それに応答します。Canonicalが適切であると判断した場合は、レベル4の問題を示すケースに応答後、それをクローズできるものとします。</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="eight-col">
+
+        <h3 id="ua-support-hotfixes">4. ホットフィックス</h3>
+
+        <p>クリティカルなケースを暫定的に解決するため、Canonicalは、影響を受けるソフトウェア (パッケージなど) のパッチ適用バージョンを提供する場合があります。このようなバージョンは「ホットフィックス」と呼ばれます。Canonicalが提供するホットフィックスは、そのパッチがUbuntu Archivesのソフトウェアのリリースに適用された後、90日間有効です。ただし、上流プロジェクトでパッチが拒否された場合、ホットフィックスのサポートは終了し、ケースはオープンの状態が継続します。</p>
+
+
+        <h3 id="ua-support-languages">5. 言語</h3>
+        <p>Canonicalは英語でサポートを提供します。タイミングによってはその他の言語が利用可能な場合があります。</p>
+
+        <h3 id="ua-support-remote-sessions">6. リモートセッション</h3>
+        <ol class="numbered">
+            <li><span class="number">6.1</span> Canonicalは、リモートアクセスサービスを使用し、顧客のサポート対象システムへのアクセスを提供できるものとします。この場合、使用するリモートアクセスサービスはCanonicalが決定します。</li>
+        </ol>
+
+        <h3 id="ua-support-regions">7. サポート地域</h3>
+        <p>Canonicalは、以下の国を含むどの場所からもサービスを提供できます。</p>
+        <ul>
+            <li>オーストラリア</li>
+            <li>ブラジル</li>
+            <li>カナダ</li>
+            <li>チリ</li>
+            <li>中国</li>
+            <li>クロアチア</li>
+            <li>フィンランド</li>
+            <li>フランス</li>
+            <li>ドイツ</li>
+            <li>ハンガリー</li>
+            <li>イタリア</li>
+            <li>日本</li>
+            <li>ノルウェー</li>
+            <li>ポーランド</li>
+            <li>韓国</li>
+            <li>スペイン</li>
+            <li>スウェーデン</li>
+            <li>台湾</li>
+            <li>英国</li>
+            <li>米国</li>
+        </ul>
+    </div>
+    <!-- / Appendix 2 -->
+
+    <div class="eight-col">
+        <p><a href="#service-description">先頭へ戻る</a></p>
+    </div>
+</div><!-- /.row -->
+
+<div class="row no-border no-border" id="appendix-3">
+    <div class="eight-col">
+
+        <h2 id="ua-escalation">付録3 - Ubuntu Advantageマネジメントエスカレーション</h2>
+        <p>サービスに不満がある場合は、いくつかの方法でその状況をCanonicalの経営陣にエスカレーションできます。</p>
+
+        <h3>ケース終了後のフィードバック</h3>
+        <p>ケースがクローズされると、Canonicalのサポートの全体的な経験に関するアンケートがケースオーナーにメールで送信されます。すべてのアンケートは経営陣によってレビューされます。</p>
+
+        <h3>ピアレビューの依頼</h3>
+        <p>Canonicalでは、通常の慣習として、全ケースの特定の割合に対してピアレビューを行っています。顧客はケースのピアレビューを、ケースコメントまたは電話 (+1 514 940 8895) で請求できます。偏見のないエンジニアがケースレビューに任命され、フィードバックを提供します。</p>
+
+        <h3>マネジメントエスカレーション</h3>
+        <p>緊急でないニーズ：</p>
+        <ul>
+            <li>ケース自体の中でマネジメントエスカレーションを要求してください。マネージャーは、ケースをレビューして1営業日以内に応答する必要がある旨の連絡を受け取ります。</li>
+        </ul>
+        <p>緊急なニーズ：</p>
+        <ul>
+            <li>Canonicalのサポートおよびテクニカルサービスマネージャーにメール (<a href="mailto:%73%75%70%70%6F%72%74%2D%6D%61%6E%61%67%65%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">support-manager@canonical.com</a>) または電話 (<a href="tel:+15149408910">+1 514 940 8910</a>) でエスカレーションできます。</li>
+            <li>さらにエスカレーションが必要な場合は、Canonicalのサポートおよびテクニカルサービスディレクターにメール (<a href="mailto:%6F%70%65%72%61%74%69%6F%6E%73%2D%64%69%72%65%63%74%6F%72%40%63%61%6E%6F%6E%69%63%61%6C%2E%63%6F%6D">operations-director@canonical.com</a>) でご連絡ください。</li>
+        </ul>
+
+    </div>
+    <!-- / Appendix 3 -->
+
+    <div class="eight-col">
+        <p><a href="#service-description">先頭へ戻る</a></p>
+    </div>
+</div><!-- /.row -->
+
+{% endblock content %}

--- a/templates/legal/ubuntu-advantage/service-description-ja.html
+++ b/templates/legal/ubuntu-advantage/service-description-ja.html
@@ -10,7 +10,7 @@
 <div class="row row-hero no-border" id="service-description">
     <div class="eight-col">
 
-        <h1>Ubuntu Advantageサービス記述書</h1>
+        <h1>Ubuntu Advantage<br/>サービス記述書</h1>
 
         <p class="intro">2016年10月2日より有効</p>
 
@@ -45,25 +45,26 @@
         <ol class="numbered">
             <li id="support-scope-releases"><span class="number">2.1</span> リリース
                 <ul>
-                    <li>Canonicalは、プロジェクトのライフサイクル中に公式ソースを使用してインストールされたUbuntuの全標準リリースのインストール、設定、保守、および管理に関するサポートを提供します。Ubuntuのバージョン別ライフサイクルについては、こちらをご覧ください：<a href="/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a>。</li>
+                    <li>Canonicalは、プロジェクトのライフサイクル中に公式ソースを使用してインストールされたUbuntuの全標準リリースのインストール、設定、保守、および管理に関するサポートを提供します。Ubuntuのバージョン別ライフサイクルについては、こちらをご覧ください：<br /><a href="/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a></li>
                 </ul>
             </li>
             <li id="support-scope-hardware"><span class="number">2.2</span> ハードウェア
                 <ul>
-                    <li>Ubuntu認定ハードウェアは、当社の広範なテストおよびレビュープロセスに合格しています。Ubuntu認定プロセスの詳細および認定ハードウェアの一覧については、Ubuntu認定ページをご覧ください： <a href="https://certification.ubuntu.com">www.ubuntu.com/certification</a>。本サービスは、顧客の認定ハードウェアのみに適用されます。認定されていないハードウェアのサービスを顧客から依頼された場合、Canonicalはサポートサービスを提供するために合理的な努力を払いますが、本サービス記述書に記載された義務に従わない場合があります。</li>
+                    <li>Ubuntu認定ハードウェアは、当社の広範なテストおよびレビュープロセスに合格しています。Ubuntu認定プロセスの詳細および認定ハードウェアの一覧については、Ubuntu認定ページをご覧ください： <a href="https://certification.ubuntu.com">www.ubuntu.com/certification</a>。</li>
+                    <li>本サービスは、顧客の認定ハードウェアのみに適用されます。認定されていないハードウェアのサービスを顧客から依頼された場合、Canonicalはサポートサービスを提供するために合理的な努力を払いますが、本サービス記述書に記載された義務に従わない場合があります。</li>
                 </ul>
             </li>
             <li id="support-scope-packages"><span class="number">2.3</span> パッケージ
                 <ol class="numbered">
-                    <li><span class="number">2.3.1</span> サービスは、Ubuntu MainリポジトリにあるパッケージおよびUniverse RepositoryにあるCanonical所有のパッケージのみに適用されます。ただし、(i) 「提案」および「バックポート」リポジトリポケット、および (ii) 該当するサポート範囲文書に記載された除外事項は除きます。<br />
+                    <li><span class="number">2.3.1</span> 本サービスは、Ubuntu MainリポジトリにあるパッケージおよびUniverse RepositoryにあるCanonical所有のパッケージのみに適用されます。ただし、(i) 「proposed」および「backports」リポジトリポケット、および (ii) 該当するサポート範囲文書に記載された除外事項は除きます。<br />
                     Universe Repositoryのサポート対象パッケージには、Jujuパッケージ、MAASパッケージ、nova-conductorパッケージ、およびこれらのパッケージと関連して使用される依存パッケージが含まれます。</li>
                     <li><span class="number">2.3.2</span> Ubuntuアーカイブにあるバージョンから変更されているパッケージはサポート対象外です。</li>
                 </ol>
             </li>
             <li id="support-scope-kernels"><span class="number">2.4</span> カーネル
                 <ol class="numbered">
-                    <li><span class="number">2.4.1</span> Ubuntuの長期サポート (LTS） バージョンのリリースで最初に提供されたカーネルは、LTSの全ライフサイクルにおいてサポートされます。</li>
-                    <li><span class="number">2.4.2</span> ハードウェアイネーブルメント (HWE) カーネルは、LTSリリースでより新しいハードウェアに対するサポートを提供し、非LTS Ubuntuリリースと共にリリースされます。HWEカーネルは、次のLTSポイントリリースまでサポートされます。</li>
+                    <li><span class="number">2.4.1</span> Ubuntuの長期サポート (LTS) バージョンのリリースで最初に提供されたカーネルは、LTSの全ライフサイクルにおいてサポートされます。</li>
+                    <li><span class="number">2.4.2</span> ハードウェアイネーブルメント (HWE) カーネルは、LTSリリースでより新しいハードウェアに対するサポートを提供し、非LTS Ubuntuリ<br />リースと共にリリースされます。HWEカーネルは、次のLTSポイントリリースまでサポートされます。</li>
                     <li><span class="number">2.4.3</span> カーネルのサポートに関する詳細についてはこちらをご覧ください。 <a href="/info/release-end-of-life">www.ubuntu.com/info/release-end-of-life</a></li>
                 </ol>
             </li>
@@ -85,11 +86,11 @@
                     <li><span class="number">2.6.2</span> OpenStackサポートには、サポート対象ノードが5つ以上ある環境が必要です。</li>
                     <li><span class="number">2.6.3</span> Canonical Architectureとは以下を指します：
                         <ul>
-                            <li>Juju、MAAS、および公式チャームリリースを使用してCanonicalとの契約に基づいてデプロイされたUbuntu OpenStackインストール。Canonicalとの契約に基づいてデプロイした結果、チャームのカスタマイズが必要になった場合、カスタマイズの有効期間はそのカスタマイズを含むチャームの公式リリース後90日間です。</li>
+                            <li>Juju、MAAS、および公式チャームリリースを使用してCanonicalとの契約に基づいてデプロイされたUbuntu OpenStack環境。Canonicalとの契約に基づいてデプロイした結果、チャームのカスタマイズが必要になった場合、カスタマイズの有効期間はそのカスタマイズを含むチャームの公式リリース後90日間です。</li>
                             <li>CanonicalのOpenStack Autopilotを使用したUbuntu OpenStackのデプロイメント。</li>
                         </ul>
                     </li>
-                    <li><span class="number">2.6.4</span> Canonical Architectureを使用しないでデプロイされたインストールについては、サポートはUbuntu OpenStackパッケージ自体のバグに限定されます。また、OpenStackインストールのデプロイ、設定、または問題最適化に関するサポートは含まれません。</li>
+                    <li><span class="number">2.6.4</span> Canonical Architectureを使用しないでデプロイされた環境については、サポートはUbuntu OpenStackパッケージ自体のバグに限定されます。また、OpenStackインストールのデプロイ、設定、または問題最適化に関するサポートは含まれません。</li>
                     <li><span class="number">2.6.5</span> デプロイされたノード1つにつき合計で最大3TBの使用可能ストレージに対するサポート。この許容量は、Ubuntu Advantage Ceph、Ubuntu Advantage Swift、またはこれらの組み合わせに対して使用できます。</li>
                     <li><span class="number">2.6.6</span> サポート対象のOpenStackバージョン:
                         <ul>
@@ -142,8 +143,8 @@
             <li><a href="#ua-maas">MAAS&nbsp;&rsaquo;</a></li>
             <li><a href="#ua-switch">Switch&nbsp;&rsaquo;</a></li>
             <li><a href="#ua-desktop">Desktop&nbsp;&rsaquo;</a></li>
-            <li><a href="#ua-landscape-virtual-machines">仮想マシンのLandscapeエージェント&nbsp;&rsaquo;</a></li>
-            <li><a href="#tam">テクニカルアカウントマネージャー (TAM)&nbsp;&rsaquo;</a></li>
+            <li><a href="#ua-landscape-virtual-machines">仮想マシンのLandscapeエー<br />ジェント&nbsp;&rsaquo;</a></li>
+            <li><a href="#tam">テクニカルアカウントマネー<br />ジャー (TAM)&nbsp;&rsaquo;</a></li>
             <li><a href="#dedicated-services-engineer">専任サービスエンジニア (DSE)&nbsp;&rsaquo;</a></li>
             <li><a href="#landscape-on-premises">Landscape On Premises&nbsp;&rsaquo;</a></li>
         </ol>
@@ -276,7 +277,7 @@
 
         <h2 id="assurance">5. 保証</h2>
         <ol class="numbered">
-            <li><span class="number">5.1</span> 顧客は、利用規約に従って、Ubuntu保証プログラムに加入する権利を有します。Canonicalは、保証プログラムおよびその規約を定期的に更新することができます。現在のUbuntu保証プログラムおよびそのIP免責条項はUbuntu保証ページでご覧いただけます：<a href="/legal/ubuntu-advantage/assurance">www.ubuntu.com/legal/ubuntu-advantage/assurance</a>。</li>
+            <li><span class="number">5.1</span> 顧客は、利用規約に従って、Ubuntu保証プログラムに加入する権利を有します。Canonicalは、保証プログラムおよびその規約を定期的に更新することができます。現在のUbuntu保証プログラムおよびそのIP免責条項はUbuntu保証ページでご覧いただけます：<br /><a href="/legal/ubuntu-advantage/assurance">www.ubuntu.com/legal/ubuntu-advantage/assurance</a>。</li>
         </ol>
     </div><!-- /.eight-col -->
 </div><!-- /.row -->
@@ -370,7 +371,7 @@
                     <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
                 </tr>
                 <tr>
-                    <td scope="row">24x7 Ubuntu main内のすべてのパッケージに対する電話およびチケットサポート (<a href="#response-times">セクション3</a>を参照)、およびバックポートおよびuniverse内のCanonical作成パッケージ。ただし<a href="#kvm-guest-support">このセクション</a>に記載されているものを除く</td>
+                    <td scope="row">24x7 Ubuntu Main内のすべてのパッケージに対する電話およびチケットサポート (<a href="#response-times">セクション3</a>を参照)、およびバックポートおよびuniverse内のCanonical作成パッケージ。ただし<a href="#kvm-guest-support">このセクション</a>に記載されているものを除く</td>
                     <td></td>
                     <td></td>
                     <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
@@ -432,7 +433,7 @@
         <h3 id="ua-virtual-guest">Ubuntu Advantage Virtual Guest</h3>
 
         <ul>
-            <li>Ubuntu Serverに対してサービスが提供されるのは、物理ホスト上の仮想化された環境またはUbuntuの認定パブリッククラウドパートナーの環境でインストールおよび実行されている場合です。認定パブリッククラウドパートナーについては、Ubuntuパートナー一覧をご覧ください：<a href="http://partners.ubuntu.com/find-a-partner">partners.ubuntu.com/find-a-partner</a></li>
+            <li>Ubuntu Serverに対してサービスが提供されるのは、物理ホスト上の仮想化された環境またはUbuntuの認定パブリッククラウドパートナーの環境でインストールおよび実行されている場合です。認定パブリッククラウドパートナーについては、Ubuntuパートナー一覧をご覧ください：<br /><a href="http://partners.ubuntu.com/find-a-partner">partners.ubuntu.com/find-a-partner</a></li>
             <li>サービス除外は、該当するUbuntu Advantage Serverサービスのサービス除外と同じです。</li>
         </ul>
 
@@ -444,7 +445,7 @@
             <li>「クラスタ」とは、単一の物理データセンター内にある単一のCephインストールを指します。</li>
         </ul>
 
-        <p>サポートは、すべてのストレージプールのCephに格納されている合計データ数 (ギガバイト) によって評価されます。空き領域とすべての複製およびイレージャーコーディングオーバーヘッドは除外されます。</p>
+        <p>サポートは、すべてのストレージプールのCephに格納されている合計データ数 (ギガバイト) によって評価されます。空き領域とすべての複製およびイレージャー<br />コーディングオーバーヘッドは除外されます。</p>
 
         <p>Jujuを使用してCephダッシュボードが環境にデプロイされている必要があります。</p>
 
@@ -454,13 +455,13 @@
 
         <ul>
             <li>Cephデプロイメントの実行に必要なすべてのパッケージに対するサポート。</li>
-            <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサポート。これには、Cephモニターなど予備 (ストレージ以外の) ノードが含まれます。</li>
+            <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサポー<br />ト。これには、Cephモニターなど予備 (ストレージ以外の) ノードが含まれます。</li>
         </ul>
 
         <p>サービスから除外されるもの：</p>
 
         <ul>
-            <li>Cephプロイメントの実行に必要でないワークロードに対するサポート。</li>
+            <li>Cephデプロイメントの実行に必要でないワークロードに対するサポート。</li>
         </ul>
 
         <h3 id="ua-swift-storage">Ubuntu Advantage Swift Storage</h3>
@@ -471,7 +472,7 @@
             <li>「クラスタ」とは、単一の物理データセンター内にある単一のSwiftインストールを指します。</li>
         </ul>
 
-        <p>サポートは、すべてのストレージプールのSwiftに格納されている合計データ数 (ギガバイト) によって評価されます。空き領域とすべての複製およびイレージャーコーディングオーバーヘッドは除外されます。</p>
+        <p>サポートは、すべてのストレージプールのSwiftに格納されている合計データ数 (ギガバイト) によって評価されます。空き領域とすべての複製およびイレー<br />ジャーコーディングオーバーヘッドは除外されます。</p>
 
         <p>無制限のストレージ容量に対するUbuntu Advantage Swift Storageを購入した顧客は、単一クラスタでのサポートに制限されます。</p>
 
@@ -479,13 +480,13 @@
 
         <ul>
             <li>Swiftデプロイメントの実行に必要なすべてのパッケージに対するサポート。</li>
-            <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサポート。これには、Swiftモニターなど予備 (ストレージ以外の) ノードが含まれます。</li>
+            <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサポー<br />ト。これには、Swiftモニターなど予備 (ストレージ以外の) ノードが含まれます。</li>
         </ul>
 
         <p>サービスから除外されるもの：</p>
 
         <ul>
-            <li>Swiftプロイメントの実行に必要でないワークロードに対するサポート。</li>
+            <li>Swiftデプロイメントの実行に必要でないワークロードに対するサポート。</li>
         </ul>
 
         <h3 id="ua-maas">Ubuntu Advantage MAAS</h3>
@@ -503,7 +504,7 @@
         <p>サービスから除外されるもの：</p>
 
         <ul>
-            <li>MAASデプロイメントの実行に必要でないワークロード、パッケージ、およびサービスコンポーネントに対するサポート。</li>
+            <li>MAASデプロイメントの実行に必要でないワークロード、パッケージ、および<br />サービスコンポーネントに対するサポート。</li>
             <li>MAASを使用してデプロイされたノードのサポート。</li>
             <li>MAASデプロイメントの設計および実装詳細のサポート。</li>
         </ul>
@@ -511,7 +512,7 @@
         <p>サポートされるMAASバージョン：</p>
 
         <ul>
-            <li>MAASバージョンは、Ubuntuアーカイブにリリースされた日付から1年間、UbuntuのLTSバージョンでサポートされます。</li>
+            <li>MAASのバージョンはLTSバージョンのUbuntuで、Ubuntuアーカイブにリリースされた日付から1年間サポートされます。</li>
         </ul>
 
         <h3 id="ua-switch">Ubuntu Advantage Switch</h3>
@@ -644,7 +645,7 @@
         <p>サービスから除外されるもの：</p>
 
         <ul>
-            <li>Landscape On Premisesパッケージのサポート以上のサポート。</li>
+            <li>Landscape On Premisesパッケージに関係しないもののサポート。</li>
         </ul>
 
         <p>サポートされるLandscape On Premisesバージョン：</p>
@@ -663,7 +664,7 @@
 <div class="row no-border no-border" id="appendix-2">
     <div class="eight-col">
 
-        <h2 id="ua-support-process">付録2 - Ubuntu Advantageサポートプロセス</h2>
+        <h2 id="ua-support-process">付録2 - Ubuntu Advantageサポート<br />プロセス</h2>
 
         <h3 id="ua-support-service-initiation">1. サービス開始</h3>
 
@@ -753,7 +754,7 @@
             <tr>
                 <th><strong>重大度レベル3</strong><br />
                 標準のサポート要求</th>
-                <td>Canonicalは、該当する営業時間中、回避策または恒久的な解決策をできるだけ早く顧客に提供するよう、上位の重大度レベルのケースとのバランスを取りつつ合理な努力を払います。回避策が提供された場合、Canonicalのサポートエンジニアは、ケースに対する恒久的な解決策を見つけるよう引き続き努力します。</td>
+                <td>Canonicalは、該当する営業時間中、回避策または恒久的な解決策をできるだけ早く顧客に提供するよう、上位の重大度レベルのケースとのバランスを取りつつ合理的な努力を払います。回避策が提供された場合、Canonicalのサポートエンジニアは、ケースに対する恒久的な解決策を見つけるよう引き続き努力します。</td>
             </tr>
 
             <tr>
@@ -821,7 +822,7 @@
         <p>ケースがクローズされると、Canonicalのサポートの全体的な経験に関するアンケートがケースオーナーにメールで送信されます。すべてのアンケートは経営陣によってレビューされます。</p>
 
         <h3>ピアレビューの依頼</h3>
-        <p>Canonicalでは、通常の慣習として、全ケースの特定の割合に対してピアレビューを行っています。顧客はケースのピアレビューを、ケースコメントまたは電話 (+1 514 940 8895) で請求できます。偏見のないエンジニアがケースレビューに任命され、フィードバックを提供します。</p>
+        <p>Canonicalでは、全ケースの特定の割合に対してピアレビューを行っています。顧客はケースのピアレビューを、ケースコメントまたは電話 (+1 514 940 8895) で請求できます。偏見のないエンジニアがケースレビューに任命され、フィードバックを提供します。</p>
 
         <h3>マネジメントエスカレーション</h3>
         <p>緊急でないニーズ：</p>

--- a/templates/legal/ubuntu-advantage/service-description-ja.html
+++ b/templates/legal/ubuntu-advantage/service-description-ja.html
@@ -50,7 +50,7 @@
             </li>
             <li id="support-scope-hardware"><span class="number">2.2</span> ハードウェア
                 <ul>
-                    <li>Ubuntu認定ハードウェアは、当社の広範なテストおよびレビュープロセスに合格しています。Ubuntu認定プロセスの詳細および認定ハードウェアの一覧については、Ubuntu認定ページをご覧ください： <a href="https://certification.ubuntu.com">www.ubuntu.com/certification</a>。</li>
+                    <li>Ubuntu認定ハードウェアは、当社の広範なテストおよびレビュープロセスに合格しています。Ubuntu認定プロセスの詳細および認定ハードウェアの一覧については、Ubuntu認定ページをご覧ください： <a href="https://certification.ubuntu.com">www.ubuntu.com/certification</a></li>
                     <li>本サービスは、顧客の認定ハードウェアのみに適用されます。認定されていないハードウェアのサービスを顧客から依頼された場合、Canonicalはサポートサービスを提供するために合理的な努力を払いますが、本サービス記述書に記載された義務に従わない場合があります。</li>
                 </ul>
             </li>
@@ -277,7 +277,7 @@
 
         <h2 id="assurance">5. 保証</h2>
         <ol class="numbered">
-            <li><span class="number">5.1</span> 顧客は、利用規約に従って、Ubuntu保証プログラムに加入する権利を有します。Canonicalは、保証プログラムおよびその規約を定期的に更新することができます。現在のUbuntu保証プログラムおよびそのIP免責条項はUbuntu保証ページでご覧いただけます：<br /><a href="/legal/ubuntu-advantage/assurance">www.ubuntu.com/legal/ubuntu-advantage/assurance</a>。</li>
+            <li><span class="number">5.1</span> 顧客は、利用規約に従って、Ubuntu保証プログラムに加入する権利を有します。Canonicalは、保証プログラムおよびその規約を定期的に更新することができます。現在のUbuntu保証プログラムおよびそのIP免責条項はUbuntu保証ページでご覧いただけます：<br /><a href="/legal/ubuntu-advantage/assurance">www.ubuntu.com/legal/ubuntu-advantage/assurance</a></li>
         </ol>
     </div><!-- /.eight-col -->
 </div><!-- /.row -->
@@ -299,8 +299,8 @@
 
         <p>追加でサービスに含まれるもの：</p>
         <ul>
-            <li>OpenStackの実行に必要なすべてのパッケージに対するサポート。</li>
-            <li>クラウドゲスト向けUbuntu Advantage Server Advanced services。</li>
+            <li>OpenStackの実行に必要なすべてのパッケージに対するサポート</li>
+            <li>クラウドゲスト向けUbuntu Advantage Server Advanced services</li>
             <li>Landscape On Premises</li>
         </ul>
 
@@ -455,7 +455,7 @@
 
         <ul>
             <li>Cephデプロイメントの実行に必要なすべてのパッケージに対するサポート。</li>
-            <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサポー<br />ト。これには、Cephモニターなど予備 (ストレージ以外の) ノードが含まれます。</li>
+            <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサ<br />ポート。これには、Cephモニターなど予備 (ストレージ以外の) ノードが含まれます。</li>
         </ul>
 
         <p>サービスから除外されるもの：</p>
@@ -480,7 +480,7 @@
 
         <ul>
             <li>Swiftデプロイメントの実行に必要なすべてのパッケージに対するサポート。</li>
-            <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサポー<br />ト。これには、Swiftモニターなど予備 (ストレージ以外の) ノードが含まれます。</li>
+            <li>ストレージおよび複製要件を満たすために必要なすべてのサービスに対するサ<br />ポート。これには、Swiftモニターなど予備 (ストレージ以外の) ノードが含まれます。</li>
         </ul>
 
         <p>サービスから除外されるもの：</p>

--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -164,6 +164,14 @@
             <h3><a href="#appendix-3">Appendix 3 - Management escalation&nbsp;&rsaquo;</a></h3>
         </div>
 
+
+        <div class="box four-col last-col">
+            <h3>Japanese translation</h3>
+            <ul class="list">
+                <li class="last-item"><a href="/legal/ubuntu-advantage/service-description-ja">UA 略式サービス契約&nbsp;›</a></li>
+            </ul>
+        </div>
+
         <div class="eight-col">
 
             <h2 id="response-times">3. Response times</h2>

--- a/templates/legal/ubuntu-advantage/ua-terms.html
+++ b/templates/legal/ubuntu-advantage/ua-terms.html
@@ -3,140 +3,139 @@
 {% block title %}Short Form Services Agreement{% endblock %}
 
 {% block second_level_nav_items %}
-	{% include "templates/_nav_breadcrumb.html" with section_title="Legal" subsection_title="Ubuntu Advantage" page_title="Service description" %}
+    {% include "templates/_nav_breadcrumb.html" with section_title="Legal" subsection_title="Ubuntu Advantage" page_title="Service description" %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
 <div class="row no-border">
-	<div class="eight-col">
-		<h1>UA Short Form Services Agreement</h1>
-		<p>This short form services agreement (the “Agreement”) takes effect as of the date Customer signs an Order incorporating its terms or otherwise accepts its terms as part of a Registration Process (the “Effective Date”) between, Canonical Group Limited, a company registered in England (company number 6870835) whose registered office is at 5th Floor, Blue Fin Building, 110 Southwark Street, London SE1 0SU, United Kingdom (“Canonical”), and the customer identified in the Order (“Customer”).</p>
-
-		<ol class="unstyled">
-			<li>
-				<h2>1. Interpretation</h2>
-				<p>When used in this Agreement, the following terms mean:</p>
-				<p><strong>Affiliate</strong>: a corporate entity that directly or indirectly controls, is controlled by, or is under common control with a party, where “control” means ownership of more than 50% of the outstanding shares or securities representing the right to vote for the election of directors or other managing authority of such corporate entity.</p>
-				<p><strong>Confidential Information</strong>: the terms of this Agreement, and any information identified by the disclosing party as confidential or which the receiving party reasonably ought to know is confidential in light of the nature of the information or the circumstances of its disclosure.</p>
-				<p><strong>Fee(s)</strong>: the amounts payable by Customer for the Services, as set out in the Order.</p>
-				<p><strong>Intellectual Property Rights</strong>: all vested and future rights of copyright and related rights, design rights, database rights, patents, rights to inventions, trade marks and get-up (and goodwill attaching to those trade marks and that get up), domain names, applications for and the right to apply for any of the above, moral rights, goodwill (and the right to sue for passing off and unfair competition), rights in know-how, rights in confidential information, rights in computer software and semiconductor topographies, and any other intellectual or industrial property rights or equivalent forms of protection, whether or not registered or capable of registration, and all renewals and extensions of such rights, whether now known or in future subsisting in any part of the world.</p>
-				<p><strong>Open Source Software</strong>: any software which is distributed under any of the many known variations of licence terms which allow the free distribution and modification of the software’s source code or which require all distributors to make such source code freely available upon request, including any contributions or modifications thereto made by such distributor.</p>
-				<p><strong>Order</strong>: If Customer is buying Services directly from Canonical: Customer's order for Services which incorporates this Agreement and identifies Customer's name, contact information, Services, Fees, and Services Term.  If Customer is buying Services through Canonical's reseller: Customer's agreement to purchase the Services and pay applicable Fees.</p>
-				<p><strong>Registration Process</strong>: The process under which a Customer registers with Canonical to receive Services purchased through Canonical's reseller.</p>
-				<p><strong>Services</strong>: the services to be performed by Canonical as identified in the Order and described at <a href="http://www.canonical.com/ua-servicedescription">www.canonical.com/ua-servicedescription</a> as of the Effective Date.</p>
-				<p><strong>Services Term</strong>: the period for time beginning when Canonical first makes the Services available to Customer and ending after the period of time specified in the Order.</p>
-				<p><strong>Ubuntu</strong>: a version of the operating system known as “Ubuntu”, which is supported by Canonical pursuant to Canonical's public announcements and support schedule and is either Canonical's standard version with no modifications or a version modified by Canonical.</p>
-			</li>
-			<li>
-				<h2>2. Services</h2>
-				<ol class="numbered">
-					<li><span class="number">2.1</span> Canonical will make the Services available to Customer within 5 days of any of the following events: (i) Canonical receives a purchase order from Customer for the Fees, (ii) Customer pays the Fees to Canonical, or (iii) Canonical's reseller orders the Services with respect to Customer.  Subject to this Agreement, including Customer's payment of the Fees, Canonical will provide the Services during the Services Term using reasonable skill and care and through suitably qualified employees and contractors.</li>
-					<li><span class="number">2.2</span> Canonical is not obligated to perform (i) any service or function except as expressly identified in the Order (ii) any Services to the extent its performance is limited by Customer's failure to meet any reasonable dependency.</li>
-				</ol>
-			</li>
-			<li>
-				<h2>3. Intellectual Property Rights</h2>
-				<ol class="numbered">
-					<li><span class="number">3.1</span> Each party will retain ownership of its Intellectual Property Rights and any Intellectual Property Rights it creates or obtains. Nothing Canonical creates or provides under this Agreement will be considered a “work made for hire”, and no Intellectual Property Rights will transfer under this Agreement.</li>
-					<li><span class="number">3.2</span> Ubuntu is licensed under applicable Open Source Software licences and not this Agreement.  If Canonical creates or provides any software to Customer in the course of providing the Services, Canonical will provide such software under an Open Source Software licence, unless otherwise licensed under this Agreement.</li>
-					<li><span class="number">3.3</span> During and after the term of this Agreement, Customer will comply with Canonical's Intellectual Property Rights policy at <a href="https://www.ubuntu.com/legal/terms-and-policies/intellectual-property-policy">https://www.ubuntu.com/legal/terms-and-policies/intellectual-property-policy</a>.</li>
-					<li><span class="number">3.4</span> With respect to Services which include Canonical's “Landscape Dedicated Server” product (the “LDS Product”), Canonical hereby grants to Customer, subject to all Open Source Software licences, a world-wide, non-exclusive, non-transferable, revocable (in the event of breach or termination of this Agreement) licence, during the term of this Agreement, to (i) use the LDS Product in accordance with this Agreement and subject to any quantity or usage limitations set forth in the Order and (ii) to make a reasonable number of copies of the LDS Product for backup and installation purposes. Customer may not: use, copy, modify, disassemble, decompile, reverse engineer, or distribute the LDS Product except as expressly permitted in this Agreement; permit access to the LDS Product to any third party other than those acting on Customer's behalf; or move the LDS Product from one machine to another without the prior written consent of Canonical.</li>
-					<li><span class="number">3.5</span> With respect to Services which include Canonical's paravirtualized drivers for Microsoft Windows systems to run as guests on Ubuntu (the “VirtIO Drivers”), Canonical hereby grants to Customer, a world-wide, non-exclusive, non-transferable, revocable (in the event of breach or termination of this Agreement) licence, during the term of the applicable Services, to (i) use the VirtIO Drivers in accordance with this Agreement solely in connection with those computer systems for which Customer has purchased the Services, (ii) to make a reasonable number of copies of the VirtIO Drivers for backup and installation purposes.  Customer may not: use, copy, modify, disassemble, decompile, reverse engineer, or distribute the VirtIO Drivers except as expressly permitted in this Agreement or permit access to the VirtIO Drivers to any third party other than those acting on Customer's behalf, and (iii) to distribute the VirtIO Drivers to third party users of Customer's cloud computing services.  In connection with the distribution licence granted under (iii) of the preceding sentence, Customer may sublicense the licence granted under (i) and (ii) of the preceding sentence to third party users Customer's cloud computing services.   Such sublicence must be on terms that are no less protective of Canonical's rights than those of this Agreement, and must be revoked upon the revocation of the licence under this Clause 3.5.</li>
-				</ol>
-			</li>
-			<li>
-				<h2>4. Customer responsibilities</h2>
-				<ol class="numbered">
-					<p><span class="number">4.1</span> Customer will not (i) use the Services other than in connection with the Customer systems for which Customer has purchased the Services or (ii) resell the Services.</p>
-					<p><span class="number">4.2</span> Customer is responsible for the back-up of its data and software.  Canonical will not be liable for any loss, corruption, or damage to data or software.</p>
-					<p><span class="number">4.3</span> If Customer engages Canonical to install or use any third party software or materials as part of the Services, Customer will have and maintain sufficient rights or licences to such software to allow Canonical to perform the Services.</p>
-				</ol>
-			</li>
-			<li>
-				<h2>5. Confidentiality</h2>
-				<ol class="numbered">
-					<li><span class="number">5.1</span> During and after the term of this Agreement, each party will and will cause its officers, employees, contractors and agents to keep secret and confidential all Confidential Information of the other and will not copy, use or disclose any such information to any third party, other than as may be necessary to comply with its obligations under this Agreement; provided that a party may disclose the other party's Confidential Information to Affiliates.</li>
-					<li><span class="number">5.2</span> The obligation of confidence will not apply where the Confidential Information: is required to be disclosed by operation of law; was lawfully in the possession of the recipient prior to disclosure by the other party; is subsequently lawfully acquired from a third party or independently developed by the recipient without breach of any known obligation of confidence; is or becomes generally available to the public through no act or default of the recipient; or is disclosed on a confidential basis for the purposes of obtaining professional advice.</li>
-					<li><span class="number">5.3</span> Each party will give the other prompt written notice of any disclosure of the party's Confidential Information as required by operation of law during and after the term of this Agreement.</li>
-					<li><span class="number">5.4</span> Each party agrees that damages would not be an adequate remedy for any failure to comply with the confidentiality obligations in this Agreement and that the other party will be entitled to the remedies of injunction, specific performance and/or other equitable relief for any threatened or actual failure to comply with those obligations.</li>
-				</ol>
-			</li>
-			<li>
-				<h2>6. Fees and payment</h2>
-				<ol class="numbered">
-					<li><span class="number">6.1</span> If Customer is purchasing the Services directly from Canonical, Customer will pay the Fees at the time of Customer's Order.  If Customer is purchasing the Services through Canonical's reseller, Customer shall pay the Fees in accordance with the reseller's process and the terms of this Clause 6 will not otherwise apply.</li>
-					<li><span class="number">6.2</span> The Fees are exclusive of all applicable taxes, which Customer will pay in addition to the Fees at the rate prevailing on the date of the invoice.  Any sums payable by Customer to Canonical will be paid clear of any deductions or withholdings.  In the event that Customer is required by applicable law to withhold or deduct any amounts from the Fees, Customer will pay any additional amounts necessary to ensure that Canonical is in the same position as it would have been in had no deductions or withholdings been required.</li>
-					<li><span class="number">6.3</span> During the term of this Agreement, Canonical may request Customer's confirmation of its compliance with this Agreement or, if Canonical reasonably suspects that Customer is not in compliance with this Agreement, audit Customer's use of the Services to confirm compliance.  If any audit reveals that Customer was not in compliance with the Agreement, Customer will immediately come into compliance.  If Customer's confirmation or an audit reveals that additional Fees are due, Customer will pay such Fees and interest (at the rate applicable to past due amounts), within 30 days of the date of Canonical’s invoice.  If the additional Fees exceed the Fees originally invoiced for the period covered by the audit by 5%, Customer will reimburse Canonical for the costs of the audit.</li>
-					<li><span class="number">6.4</span> Canonical may charge interest on any past due payment amounts, plus any related collection and legal costs.  Such interest will accrue at the annual rate of 2% above the base rate of the Bank of England in force from the due date until the date of payment, or the highest rate allowable by applicable law (if lower).  Interest will accrue on a daily basis, whether before or after judgement.</li>
-				</ol>
-			</li>
-			<li>
-				<h2>7. Warranty disclaimer</h2>
-				<ol class="numbered">
-					<li><span class="number">7.1</span> Neither party makes any representations or warranties of any kind, whether oral or written, whether express, implied, or arising by statute, custom, course of dealing or trade usage, with respect to the subject matter hereof or otherwise in connection with this Agreement.  Each party specifically disclaims any and all implied warranties or conditions of title, satisfactory quality, merchantability, satisfactoriness, fitness for a particular purpose and non-infringement.</li>
-				</ol>
-			</li>
-			<li>
-				<h2>8. Liability limitations</h2>
-				<ol class="numbered-paragraphs">
-					<li><span class="number">8.1</span> Subject to Clause 8.3, each party’s aggregate liability under this Agreement, in any Contract Year, whether based on contract, tort (including negligence) or otherwise, will not exceed the amount of Fees becoming payable in that particular Contract Year.  “Contract Year” means any period of 12 months commencing on the Effective Date or any anniversary of the Effective Date.</li>
-					<li><span class="number">8.2</span> Subject to Clause 8.3, neither party will be liable for any indirect, special, incidental, punitive, or consequential loss or damage or for any loss of or damage to data, ex gratia payments, loss of profit, loss of contract or loss of other economic advantage (in each case whether direct or indirect) arising out of or in connection with this Agreement, even if that party has previously been advised of the possibility of the same and whether foreseeable or not. These limitations will apply notwithstanding any failure of essential purpose of any limited remedy.</li>
-					<li><span class="number">8.3</span> Nothing in this Agreement excludes or limits the liability of either party for: (i) death or personal injury; (ii) fraud; (iii) breach of the confidentiality provisions of this Agreement, and (iv) anything else that cannot be excluded of limited by applicable law.</li>
-					<li><span class="number">8.4</span> The limitations of liability set forth in this Clause 8 are a reasonable allocation of risk between the parties, and the parties would not have entered into this Agreement, absent such allocation.</li>
-				</ol>
-			</li>
-			<li>
-				<h2>9. Term and termination</h2>
-				<ol class="numbered-paragraphs">
-					<li><span class="number">9.1</span> This Agreement will come into force on the Effective Date and will continue until the end of the Services Term unless terminated earlier under this Clause 9.</li>
-					<li><span class="number">9.2</span> Unless Customer is purchasing the Services from Canonical's reseller, if Canonical has not received a purchase order for the Fees or payment of the Fees within 30 days of the Effective Date, this Agreement will automatically terminate.</li>
-					<li><span class="number">9.3</span> Either party may terminate this Agreement immediately by written notice if the other party:</li>
-					<ul class="list-ticks">
-						<li>9.4. commits a material breach of this Agreement and, if such breach is capable of remedy, fails to remedy the breach within 14 days of receiving notice of the breach;</li>
-						<li>9.5. enters into liquidation whether compulsorily or voluntarily (otherwise than for the purposes of a solvent amalgamation or reconstruction); becomes insolvent; ceases or threatens to cease to carry on business; or any similar event.</li>
-					</ul>
-					<li><span class="number">9.6</span> Canonical may terminate this Agreement for convenience upon giving 90 days prior notice to Customer.</li>
-					<li><span class="number">9.7</span> On expiration or termination this Agreement for any reason, Canonical's obligation to provide the Services will immediately terminate and any licences granted under this Agreement will terminate, unless otherwise agreed. On termination other than by Canonical for convenience in accordance with Clause 9.4, Customer will immediately pay all outstanding Fees applicable to this Agreement including Fees that would otherwise have been payable with respect to the full Agreement term.   On termination of this Agreement by Canonical for convenience in accordance with Clause 9.4, Canonical will provide Customer with a pro rata refund of any prepaid Fees for the remaining unexpired portion of the Services term.</li>
-				</ol>
-			</li>
-			<li>
-				<h2>10. Escalation</h2>
-				<ol class="numbered">
-					<li><span class="number">10.1</span> If there is a disagreement in relation to this Agreement, the parties will use their reasonable endeavours to negotiate and settle the disagreement.  If it is not possible to settle the disagreement within 14 days, representatives of both parties will meet to try to resolve the disagreement.  If the disagreement is not resolved within a further 14 days, the disagreement may be referred by either party to a meeting between the senior managers of the parties.  Subject to Clause 10.2, neither party will refer any dispute to the courts unless and until the dispute resolution procedures of this Clause 10 have been followed.</li>
-					<li><span class="number">10.2</span> Nothing in this Clause 10 will prevent either party applying to the courts of any country for injunctive or other interim relief.</li>
-				</ol>
-			</li>
-			<li>
-				<h2>11. General</h2>
-				<ol class="numbered-paragraphs">
-					<li><span class="number">11.1</span> Neither party will be liable for any breach of this Agreement directly or indirectly caused by circumstances beyond the reasonable control of that party, provided that a lack of funds will not be regarded as a circumstance beyond that party’s reasonable control.</li>
-					<li><span class="number">11.2</span> Neither party may assign, transfer, charge, create a trust over or otherwise deal in its rights and/or obligations under this Agreement (or purport to do so) without the other party’s prior written consent except to an Affiliate pursuant to a bona fide re-structure, merger, consolidation, sale of all or substantially all of its assets, or a sale of the business to which the Services relate.</li>
-					<li><span class="number">11.3</span> There are no intended third party beneficiaries to this Agreement.  The parties do not intend that any provision of this Agreement will be enforceable by virtue of the Contracts (Rights of Third Parties) Act 1999 (England), as amended from time to time, by any person who is not a party to this Agreement.</li>
-					<li><span class="number">11.4</span> No amendment or modification of this Agreement will be binding upon the parties unless made in writing and signed by the authorized representatives of both parties.</li>
-					<li><span class="number">11.5</span> A failure or delay by a party to exercise any right or remedy under this Agreement will not be construed or operate as a waiver of that right or remedy.  Nor single or partial exercise of any right or remedy will preclude the further exercise of that right or remedy by that party.</li>
-					<li><span class="number">11.6</span> During the term of this Agreement and for 6 months thereafter, Customer will not  solicit to be hired or hire, as an employee or independent contractor, any individual (i) who is then the personnel of Canonical or any of its Affiliates or was the personnel of Canonical or any of its Affiliates during the previous 6 months (unless Canonical terminated that individual's employment or contract) and (ii) who during any part of the term of this Agreement was assigned by Canonical to provide services to Canonical's customers.</li>
-					<li><span class="number">11.7</span> This Agreement represents the entire terms agreed between the parties in relation to its subject matter and supersedes all previous contracts or arrangements (including any usage or custom and any terms arising through any course of dealing) of any kind between the parties relating to its subject matter.  No terms or conditions included in or delivered with any Customer acceptance of Services, proposal, purchase order or similar document will form part of this Agreement.</li>
-					<li><span class="number">11.8</span> Each of the provisions of this Agreement will be construed as independent of every other such provision, so that if any provision of this Agreement will be determined by any court of competent authority to be illegal, invalid and/or unenforceable this will not affect any other provision of this Agreement, which will remain in full force and effect.</li>
-					<li><span class="number">11.9</span> Nothing in this Agreement and no action taken by the parties pursuant to this Agreement will be construed as creating a partnership or joint venture of any kind between the parties or as constituting either party as the agent of the other party.  No party will have the authority to bind the other party or to contract in the name of or create a liability against the other party.</li>
-					<li><span class="number">11.10</span> Any notice required to be given or sent under this Agreement will be in writing and delivered to the recipient at the address set out in this Agreement or, if no address is set out, to the recipient's registered office address.  A party may update its address by providing notice to the other party.  Valid delivery methods are (i) in-person delivery, (ii) first class registered post (or equivalent), or (iii) internationally recognized overnight courier service.</li>
-					<li><span class="number">11.11</span> Canonical may provide copies of this Agreement in different languages for information purposes.  Only the English language version of this Agreement will be binding.  In the event of any dispute, any version in any language other than English will be disregarded.</li>
-					<li><span class="number">11.12</span> Customer acknowledges that export laws and regulations of the United States and European territories may apply to materials delivered by Canonical under this Agreement.  Customer agrees that such export control laws and regulations govern its use of materials and will comply with all such laws and regulations.  Customer will not export, directly or indirectly, such materials in violation of these laws or regulations, or use them for any purpose prohibited by these laws.</li>
-				</ol>
-			</li>
-			<li>
-				<h2>12. Governing law</h2>
-				<ol class="numbered-paragraphs">
-					<li><span class="number">12.1</span> This Agreement and any non-contractual obligations arising from this Agreement will be governed by and construed in accordance with the laws of England.  The parties submit to the exclusive jurisdiction of the courts of England, except when a party seeks immediate injunctive relief (for example, in connection with a breach or impending breach of confidentiality obligations) that would not be reasonably effective unless obtained in the jurisdiction of the conduct at issue.  The provisions of the United Nations Convention on Contracts for the International Sale of Goods will not apply to this Agreement.</li>
-				</ol>
-			</li>
-		</ol>
-	</div>
-	<div class="box four-col last-col">
-		<h3>Japanese translation</h3>
-		<ul class="list">
-			<li class="last-item"><a href="/legal/ubuntu-advantage/ua-terms-ja">UA 略式サービス契約&nbsp;›</a></li>
-		</ul>
-	</div>
+    <div class="eight-col">
+        <h1>UA Short Form Services Agreement</h1>
+        <p>This short form services agreement (the “Agreement”) takes effect as of the date Customer signs an Order incorporating its terms or otherwise accepts its terms as part of a Registration Process (the “Effective Date”) between, Canonical Group Limited, a company registered in England (company number 6870835) whose registered office is at 5th Floor, Blue Fin Building, 110 Southwark Street, London SE1 0SU, United Kingdom (“Canonical”), and the customer identified in the Order (“Customer”).</p>
+        <ol class="unstyled">
+            <li>
+                <h2>1. Interpretation</h2>
+                <p>When used in this Agreement, the following terms mean:</p>
+                <p><strong>Affiliate</strong>: a corporate entity that directly or indirectly controls, is controlled by, or is under common control with a party, where “control” means ownership of more than 50% of the outstanding shares or securities representing the right to vote for the election of directors or other managing authority of such corporate entity.</p>
+                <p><strong>Confidential Information</strong>: the terms of this Agreement, and any information identified by the disclosing party as confidential or which the receiving party reasonably ought to know is confidential in light of the nature of the information or the circumstances of its disclosure.</p>
+                <p><strong>Fee(s)</strong>: the amounts payable by Customer for the Services, as set out in the Order.</p>
+                <p><strong>Intellectual Property Rights</strong>: all vested and future rights of copyright and related rights, design rights, database rights, patents, rights to inventions, trade marks and get-up (and goodwill attaching to those trade marks and that get up), domain names, applications for and the right to apply for any of the above, moral rights, goodwill (and the right to sue for passing off and unfair competition), rights in know-how, rights in confidential information, rights in computer software and semiconductor topographies, and any other intellectual or industrial property rights or equivalent forms of protection, whether or not registered or capable of registration, and all renewals and extensions of such rights, whether now known or in future subsisting in any part of the world.</p>
+                <p><strong>Open Source Software</strong>: any software which is distributed under any of the many known variations of licence terms which allow the free distribution and modification of the software’s source code or which require all distributors to make such source code freely available upon request, including any contributions or modifications thereto made by such distributor.</p>
+                <p><strong>Order</strong>: If Customer is buying Services directly from Canonical: Customer's order for Services which incorporates this Agreement and identifies Customer's name, contact information, Services, Fees, and Services Term.  If Customer is buying Services through Canonical's reseller: Customer's agreement to purchase the Services and pay applicable Fees.</p>
+                <p><strong>Registration Process</strong>: The process under which a Customer registers with Canonical to receive Services purchased through Canonical's reseller.</p>
+                <p><strong>Services</strong>: the services to be performed by Canonical as identified in the Order and described at <a href="http://www.canonical.com/ua-servicedescription">www.canonical.com/ua-servicedescription</a> as of the Effective Date.</p>
+                <p><strong>Services Term</strong>: the period for time beginning when Canonical first makes the Services available to Customer and ending after the period of time specified in the Order.</p>
+                <p><strong>Ubuntu</strong>: a version of the operating system known as “Ubuntu”, which is supported by Canonical pursuant to Canonical's public announcements and support schedule and is either Canonical's standard version with no modifications or a version modified by Canonical.</p>
+            </li>
+            <li>
+                <h2>2. Services</h2>
+                <ol class="numbered">
+                    <li><span class="number">2.1</span> Canonical will make the Services available to Customer within 5 days of any of the following events: (i) Canonical receives a purchase order from Customer for the Fees, (ii) Customer pays the Fees to Canonical, or (iii) Canonical's reseller orders the Services with respect to Customer.  Subject to this Agreement, including Customer's payment of the Fees, Canonical will provide the Services during the Services Term using reasonable skill and care and through suitably qualified employees and contractors.</li>
+                    <li><span class="number">2.2</span> Canonical is not obligated to perform (i) any service or function except as expressly identified in the Order (ii) any Services to the extent its performance is limited by Customer's failure to meet any reasonable dependency.</li>
+                </ol>
+            </li>
+            <li>
+                <h2>3. Intellectual Property Rights</h2>
+                <ol class="numbered">
+                    <li><span class="number">3.1</span> Each party will retain ownership of its Intellectual Property Rights and any Intellectual Property Rights it creates or obtains. Nothing Canonical creates or provides under this Agreement will be considered a “work made for hire”, and no Intellectual Property Rights will transfer under this Agreement.</li>
+                    <li><span class="number">3.2</span> Ubuntu is licensed under applicable Open Source Software licences and not this Agreement.  If Canonical creates or provides any software to Customer in the course of providing the Services, Canonical will provide such software under an Open Source Software licence, unless otherwise licensed under this Agreement.</li>
+                    <li><span class="number">3.3</span> During and after the term of this Agreement, Customer will comply with Canonical's Intellectual Property Rights policy at <a href="http://www.ubuntu.com/legal/terms-and-policies/intellectual-property-policy">http://www.ubuntu.com/legal/terms-and-policies/intellectual-property-policy</a>.</li>
+                    <li><span class="number">3.4</span> With respect to Services which include Canonical's “Landscape Dedicated Server” product (the “LDS Product”), Canonical hereby grants to Customer, subject to all Open Source Software licences, a world-wide, non-exclusive, non-transferable, revocable (in the event of breach or termination of this Agreement) licence, during the term of this Agreement, to (i) use the LDS Product in accordance with this Agreement and subject to any quantity or usage limitations set forth in the Order and (ii) to make a reasonable number of copies of the LDS Product for backup and installation purposes. Customer may not: use, copy, modify, disassemble, decompile, reverse engineer, or distribute the LDS Product except as expressly permitted in this Agreement; permit access to the LDS Product to any third party other than those acting on Customer's behalf; or move the LDS Product from one machine to another without the prior written consent of Canonical.</li>
+                    <li><span class="number">3.5</span> With respect to Services which include Canonical's paravirtualized drivers for Microsoft Windows systems to run as guests on Ubuntu (the “VirtIO Drivers”), Canonical hereby grants to Customer, a world-wide, non-exclusive, non-transferable, revocable (in the event of breach or termination of this Agreement) licence, during the term of the applicable Services, to (i) use the VirtIO Drivers in accordance with this Agreement solely in connection with those computer systems for which Customer has purchased the Services, (ii) to make a reasonable number of copies of the VirtIO Drivers for backup and installation purposes.  Customer may not: use, copy, modify, disassemble, decompile, reverse engineer, or distribute the VirtIO Drivers except as expressly permitted in this Agreement or permit access to the VirtIO Drivers to any third party other than those acting on Customer's behalf, and (iii) to distribute the VirtIO Drivers to third party users of Customer's cloud computing services.  In connection with the distribution licence granted under (iii) of the preceding sentence, Customer may sublicense the licence granted under (i) and (ii) of the preceding sentence to third party users Customer's cloud computing services.   Such sublicence must be on terms that are no less protective of Canonical's rights than those of this Agreement, and must be revoked upon the revocation of the licence under this Clause 3.5.</li>
+                </ol>
+            </li>
+            <li>
+                <h2>4. Customer responsibilities</h2>
+                <ol class="numbered">
+                    <p><span class="number">4.1</span> Customer will not (i) use the Services other than in connection with the Customer systems for which Customer has purchased the Services or (ii) resell the Services.</p>
+                    <p><span class="number">4.2</span> Customer is responsible for the back-up of its data and software.  Canonical will not be liable for any loss, corruption, or damage to data or software.</p>
+                    <p><span class="number">4.3</span> If Customer engages Canonical to install or use any third party software or materials as part of the Services, Customer will have and maintain sufficient rights or licences to such software to allow Canonical to perform the Services.</p>
+                </ol>
+            </li>
+            <li>
+                <h2>5. Confidentiality</h2>
+                <ol class="numbered">
+                    <li><span class="number">5.1</span> During and after the term of this Agreement, each party will and will cause its officers, employees, contractors and agents to keep secret and confidential all Confidential Information of the other and will not copy, use or disclose any such information to any third party, other than as may be necessary to comply with its obligations under this Agreement; provided that a party may disclose the other party's Confidential Information to Affiliates.</li>
+                    <li><span class="number">5.2</span> The obligation of confidence will not apply where the Confidential Information: is required to be disclosed by operation of law; was lawfully in the possession of the recipient prior to disclosure by the other party; is subsequently lawfully acquired from a third party or independently developed by the recipient without breach of any known obligation of confidence; is or becomes generally available to the public through no act or default of the recipient; or is disclosed on a confidential basis for the purposes of obtaining professional advice.</li>
+                    <li><span class="number">5.3</span> Each party will give the other prompt written notice of any disclosure of the party's Confidential Information as required by operation of law during and after the term of this Agreement.</li>
+                    <li><span class="number">5.4</span> Each party agrees that damages would not be an adequate remedy for any failure to comply with the confidentiality obligations in this Agreement and that the other party will be entitled to the remedies of injunction, specific performance and/or other equitable relief for any threatened or actual failure to comply with those obligations.</li>
+                </ol>
+            </li>
+            <li>
+                <h2>6. Fees and payment</h2>
+                <ol class="numbered">
+                    <li><span class="number">6.1</span> If Customer is purchasing the Services directly from Canonical, Customer will pay the Fees at the time of Customer's Order.  If Customer is purchasing the Services through Canonical's reseller, Customer shall pay the Fees in accordance with the reseller's process and the terms of this Clause 6 will not otherwise apply.</li>
+                    <li><span class="number">6.2</span> The Fees are exclusive of all applicable taxes, which Customer will pay in addition to the Fees at the rate prevailing on the date of the invoice.  Any sums payable by Customer to Canonical will be paid clear of any deductions or withholdings.  In the event that Customer is required by applicable law to withhold or deduct any amounts from the Fees, Customer will pay any additional amounts necessary to ensure that Canonical is in the same position as it would have been in had no deductions or withholdings been required.</li>
+                    <li><span class="number">6.3</span> During the term of this Agreement, Canonical may request Customer's confirmation of its compliance with this Agreement or, if Canonical reasonably suspects that Customer is not in compliance with this Agreement, audit Customer's use of the Services to confirm compliance.  If any audit reveals that Customer was not in compliance with the Agreement, Customer will immediately come into compliance.  If Customer's confirmation or an audit reveals that additional Fees are due, Customer will pay such Fees and interest (at the rate applicable to past due amounts), within 30 days of the date of Canonical’s invoice.  If the additional Fees exceed the Fees originally invoiced for the period covered by the audit by 5%, Customer will reimburse Canonical for the costs of the audit.</li>
+                    <li><span class="number">6.4</span> Canonical may charge interest on any past due payment amounts, plus any related collection and legal costs.  Such interest will accrue at the annual rate of 2% above the base rate of the Bank of England in force from the due date until the date of payment, or the highest rate allowable by applicable law (if lower).  Interest will accrue on a daily basis, whether before or after judgement.</li>
+                </ol>
+            </li>
+            <li>
+                <h2>7. Warranty disclaimer</h2>
+                <ol class="numbered">
+                    <li><span class="number">7.1</span> Neither party makes any representations or warranties of any kind, whether oral or written, whether express, implied, or arising by statute, custom, course of dealing or trade usage, with respect to the subject matter hereof or otherwise in connection with this Agreement.  Each party specifically disclaims any and all implied warranties or conditions of title, satisfactory quality, merchantability, satisfactoriness, fitness for a particular purpose and non-infringement.</li>
+                </ol>
+            </li>
+            <li>
+                <h2>8. Liability limitations</h2>
+                <ol class="numbered-paragraphs">
+                    <li><span class="number">8.1</span> Subject to Clause 8.3, each party’s aggregate liability under this Agreement, in any Contract Year, whether based on contract, tort (including negligence) or otherwise, will not exceed the amount of Fees becoming payable in that particular Contract Year.  “Contract Year” means any period of 12 months commencing on the Effective Date or any anniversary of the Effective Date.</li>
+                    <li><span class="number">8.2</span> Subject to Clause 8.3, neither party will be liable for any indirect, special, incidental, punitive, or consequential loss or damage or for any loss of or damage to data, ex gratia payments, loss of profit, loss of contract or loss of other economic advantage (in each case whether direct or indirect) arising out of or in connection with this Agreement, even if that party has previously been advised of the possibility of the same and whether foreseeable or not. These limitations will apply notwithstanding any failure of essential purpose of any limited remedy.</li>
+                    <li><span class="number">8.3</span> Nothing in this Agreement excludes or limits the liability of either party for: (i) death or personal injury; (ii) fraud; (iii) breach of the confidentiality provisions of this Agreement, and (iv) anything else that cannot be excluded of limited by applicable law.</li>
+                    <li><span class="number">8.4</span> The limitations of liability set forth in this Clause 8 are a reasonable allocation of risk between the parties, and the parties would not have entered into this Agreement, absent such allocation.</li>
+                </ol>
+            </li>
+            <li>
+                <h2>9. Term and termination</h2>
+                <ol class="numbered-paragraphs">
+                    <li><span class="number">9.1</span> This Agreement will come into force on the Effective Date and will continue until the end of the Services Term unless terminated earlier under this Clause 9.</li>
+                    <li><span class="number">9.2</span> Unless Customer is purchasing the Services from Canonical's reseller, if Canonical has not received a purchase order for the Fees or payment of the Fees within 30 days of the Effective Date, this Agreement will automatically terminate.</li>
+                    <li><span class="number">9.3</span> Either party may terminate this Agreement immediately by written notice if the other party:</li>
+                    <ul class="list-ticks">
+                        <li>9.4. commits a material breach of this Agreement and, if such breach is capable of remedy, fails to remedy the breach within 14 days of receiving notice of the breach;</li>
+                        <li>9.5. enters into liquidation whether compulsorily or voluntarily (otherwise than for the purposes of a solvent amalgamation or reconstruction); becomes insolvent; ceases or threatens to cease to carry on business; or any similar event.</li>
+                    </ul>
+                    <li><span class="number">9.6</span> Canonical may terminate this Agreement for convenience upon giving 90 days prior notice to Customer.</li>
+                    <li><span class="number">9.7</span> On expiration or termination this Agreement for any reason, Canonical's obligation to provide the Services will immediately terminate and any licences granted under this Agreement will terminate, unless otherwise agreed. On termination other than by Canonical for convenience in accordance with Clause 9.4, Customer will immediately pay all outstanding Fees applicable to this Agreement including Fees that would otherwise have been payable with respect to the full Agreement term.   On termination of this Agreement by Canonical for convenience in accordance with Clause 9.4, Canonical will provide Customer with a pro rata refund of any prepaid Fees for the remaining unexpired portion of the Services term.</li>
+                </ol>
+            </li>
+            <li>
+                <h2>10. Escalation</h2>
+                <ol class="numbered">
+                    <li><span class="number">10.1</span> If there is a disagreement in relation to this Agreement, the parties will use their reasonable endeavours to negotiate and settle the disagreement.  If it is not possible to settle the disagreement within 14 days, representatives of both parties will meet to try to resolve the disagreement.  If the disagreement is not resolved within a further 14 days, the disagreement may be referred by either party to a meeting between the senior managers of the parties.  Subject to Clause 10.2, neither party will refer any dispute to the courts unless and until the dispute resolution procedures of this Clause 10 have been followed.</li>
+                    <li><span class="number">10.2</span> Nothing in this Clause 10 will prevent either party applying to the courts of any country for injunctive or other interim relief.</li>
+                </ol>
+            </li>
+            <li>
+                <h2>11. General</h2>
+                <ol class="numbered-paragraphs">
+                    <li><span class="number">11.1</span> Neither party will be liable for any breach of this Agreement directly or indirectly caused by circumstances beyond the reasonable control of that party, provided that a lack of funds will not be regarded as a circumstance beyond that party’s reasonable control.</li>
+                    <li><span class="number">11.2</span> Neither party may assign, transfer, charge, create a trust over or otherwise deal in its rights and/or obligations under this Agreement (or purport to do so) without the other party’s prior written consent except to an Affiliate pursuant to a bona fide re-structure, merger, consolidation, sale of all or substantially all of its assets, or a sale of the business to which the Services relate.</li>
+                    <li><span class="number">11.3</span> There are no intended third party beneficiaries to this Agreement.  The parties do not intend that any provision of this Agreement will be enforceable by virtue of the Contracts (Rights of Third Parties) Act 1999 (England), as amended from time to time, by any person who is not a party to this Agreement.</li>
+                    <li><span class="number">11.4</span> No amendment or modification of this Agreement will be binding upon the parties unless made in writing and signed by the authorized representatives of both parties.</li>
+                    <li><span class="number">11.5</span> A failure or delay by a party to exercise any right or remedy under this Agreement will not be construed or operate as a waiver of that right or remedy.  Nor single or partial exercise of any right or remedy will preclude the further exercise of that right or remedy by that party.</li>
+                    <li><span class="number">11.6</span> During the term of this Agreement and for 6 months thereafter, Customer will not  solicit to be hired or hire, as an employee or independent contractor, any individual (i) who is then the personnel of Canonical or any of its Affiliates or was the personnel of Canonical or any of its Affiliates during the previous 6 months (unless Canonical terminated that individual's employment or contract) and (ii) who during any part of the term of this Agreement was assigned by Canonical to provide services to Canonical's customers.</li>
+                    <li><span class="number">11.7</span> This Agreement represents the entire terms agreed between the parties in relation to its subject matter and supersedes all previous contracts or arrangements (including any usage or custom and any terms arising through any course of dealing) of any kind between the parties relating to its subject matter.  No terms or conditions included in or delivered with any Customer acceptance of Services, proposal, purchase order or similar document will form part of this Agreement.</li>
+                    <li><span class="number">11.8</span> Each of the provisions of this Agreement will be construed as independent of every other such provision, so that if any provision of this Agreement will be determined by any court of competent authority to be illegal, invalid and/or unenforceable this will not affect any other provision of this Agreement, which will remain in full force and effect.</li>
+                    <li><span class="number">11.9</span> Nothing in this Agreement and no action taken by the parties pursuant to this Agreement will be construed as creating a partnership or joint venture of any kind between the parties or as constituting either party as the agent of the other party.  No party will have the authority to bind the other party or to contract in the name of or create a liability against the other party.</li>
+                    <li><span class="number">11.10</span> Any notice required to be given or sent under this Agreement will be in writing and delivered to the recipient at the address set out in this Agreement or, if no address is set out, to the recipient's registered office address.  A party may update its address by providing notice to the other party.  Valid delivery methods are (i) in-person delivery, (ii) first class registered post (or equivalent), or (iii) internationally recognized overnight courier service.</li>
+                    <li><span class="number">11.11</span> Canonical may provide copies of this Agreement in different languages for information purposes.  Only the English language version of this Agreement will be binding.  In the event of any dispute, any version in any language other than English will be disregarded.</li>
+                    <li><span class="number">11.12</span> Customer acknowledges that export laws and regulations of the United States and European territories may apply to materials delivered by Canonical under this Agreement.  Customer agrees that such export control laws and regulations govern its use of materials and will comply with all such laws and regulations.  Customer will not export, directly or indirectly, such materials in violation of these laws or regulations, or use them for any purpose prohibited by these laws.</li>
+                </ol>
+            </li>
+            <li>
+                <h2>12. Governing law</h2>
+                <ol class="numbered-paragraphs">
+                    <li><span class="number">12.1</span> This Agreement and any non-contractual obligations arising from this Agreement will be governed by and construed in accordance with the laws of England.  The parties submit to the exclusive jurisdiction of the courts of England, except when a party seeks immediate injunctive relief (for example, in connection with a breach or impending breach of confidentiality obligations) that would not be reasonably effective unless obtained in the jurisdiction of the conduct at issue.  The provisions of the United Nations Convention on Contracts for the International Sale of Goods will not apply to this Agreement.</li>
+                </ol>
+            </li>
+        </ol>
+    </div>
+    <div class="box four-col last-col">
+        <h3>Japanese translation</h3>
+        <ul class="list">
+            <li class="last-item"><a href="/legal/ubuntu-advantage/ua-terms-ja">UA 略式サービス契約&nbsp;›</a></li>
+        </ul>
+    </div>
 </div>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

 - Added new Japanese service description for UA
 - Fixed issues in files I touched

## QA

 - Go to `http://10.20.66.17:8001/legal/ubuntu-advantage/service-description` click the link in "Japanese translation"
 - Check that the Japanese page displays correctly
 - Check the content against the [copydoc](https://docs.google.com/document/d/1Tpf4FuP6SzvfyFw-nlR44uAIkofNdwzDaJFY36ZAk68/edit#) as much as you are able.
