### PR TITLE
Updated Spotlight

### DIFF
--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -387,7 +387,6 @@ body.homepage .row--intro .intro-middle li a:hover {
 
 body.homepage .row--ubuntu-news {
   background-color: #fff;
-  margin-bottom: -60px;
 
   @media only screen and (min-width : 768px) {
     margin-bottom: 0px;
@@ -395,7 +394,7 @@ body.homepage .row--ubuntu-news {
   }
 
   @media only screen and (min-width : 984px) {
-    padding-top: 100px;
+    padding-top: 70px;
   }
 
   a {
@@ -411,6 +410,7 @@ body.homepage .row--ubuntu-news {
       font-size: 1em;
       text-transform: uppercase;
       margin-bottom: 30px;
+      margin-top: 20px;
 
       a {
         color: $cool-grey;

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,28 +12,33 @@
 
 
 {% get_rss_feed "https://insights.ubuntu.com/tag/spotlight/feed" limit=1 as spotlight_feed %}
-{% get_rss_feed "https://insights.ubuntu.com/feed" limit=3 exclude_items_in=spotlight_feed as insights_feed %}
-
+{% if spotlight_feed %}
+    {% get_rss_feed "https://insights.ubuntu.com/feed" limit=3 exclude_items_in=spotlight_feed as insights_feed %}
+{% else %}
+    {% get_rss_feed "https://insights.ubuntu.com/feed" limit=4 as insights_feed %}
+{% endif %}
 <section class="row row--ubuntu-news strip no-border">
     <div class="strip-inner-wrapper equal-height--vertical-divider">
-        <div class="nine-col equal-height--vertical-divider__item">
-            <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/"onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks insights feed link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">Latest news from Insights</a></span></h2>
-            {% for item in insights_feed %}
+        <div class="{% if spotlight_feed %}nine-col{% else %}twelve-col{% endif %} equal-height--vertical-divider__item">
+            <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks insights feed link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">Latest news from Insights</a></span></h2>
+{% for item in insights_feed %}
             <div class="three-col {% if forloop.last %}last-col no-margin-bottom{% endif %}">
                 <h3><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks news link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">{{ item.title }}</a></h3>
                 <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
             </div>
-            {% endfor %}
+{% endfor %}
         </div>
+{% if spotlight_feed %}
         <div class="three-col no-margin-bottom last-col equal-height--vertical-divider__item">
             <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/tag/spotlight/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks spotlight feed link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">Spotlight</a></span></h2>
-            {% for item in spotlight_feed %}
+{% for item in spotlight_feed %}
             <div class="three-col {% if forloop.last %}last-col{% endif %}">
                 <h3><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks spotlight link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">{{ item.title }}</a></h3>
                 <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
             </div>
-            {% endfor %}
+{% endfor %}
         </div>
+{% endif %}
     </div>
 </section>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,19 +17,19 @@
 <section class="row row--ubuntu-news strip no-border">
     <div class="strip-inner-wrapper equal-height--vertical-divider">
         <div class="nine-col equal-height--vertical-divider__item">
-            <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/">Latest news from Insights</a></span></h2>
+            <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/"onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks insights feed link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">Latest news from Insights</a></span></h2>
             {% for item in insights_feed %}
             <div class="three-col {% if forloop.last %}last-col no-margin-bottom{% endif %}">
-                <h3><a href="{{ item.link }}">{{ item.title }}</a></h3>
+                <h3><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks news link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">{{ item.title }}</a></h3>
                 <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
             </div>
             {% endfor %}
         </div>
         <div class="three-col no-margin-bottom last-col equal-height--vertical-divider__item">
-            <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/tag/spotlight/">Spotlight</a></span></h2>
+            <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/tag/spotlight/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks spotlight feed link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">Spotlight</a></span></h2>
             {% for item in spotlight_feed %}
             <div class="three-col {% if forloop.last %}last-col{% endif %}">
-                <h3><a href="{{ item.link }}">{{ item.title }}</a></h3>
+                <h3><a href="{{ item.link }}" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'insights', 'eventAction' : 'clicks spotlight link', 'eventLabel' : 'ubuntu.com homepage', 'eventValue' : undefined });">{{ item.title }}</a></h3>
                 <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
             </div>
             {% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,21 +10,29 @@
 
 {% include "takeovers/_core.html" %}
 
+
+{% get_rss_feed "https://insights.ubuntu.com/tag/spotlight/feed" limit=1 as spotlight_feed %}
+{% get_rss_feed "https://insights.ubuntu.com/feed" limit=3 exclude_items_in=spotlight_feed as insights_feed %}
+
 <section class="row row--ubuntu-news strip no-border">
-    <div class="strip-inner-wrapper">
-        <div class="twelve-col">
+    <div class="strip-inner-wrapper equal-height--vertical-divider">
+        <div class="nine-col equal-height--vertical-divider__item">
             <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/">Latest news from Insights</a></span></h2>
-            <div id="insights-cloud-feed" class="twelve-col">
-                <ul class="row--ubuntu-news__list no-bullets vertical-divider">
-                    {% get_rss_feed "https://insights.ubuntu.com/feed/" limit=4 as cloud_feed %}
-                    {% for item in cloud_feed %}
-                    <li class="three-col {% if forloop.last %}last-col{% endif %}">
-                        <h3><a href="{{ item.link }}">{{ item.title }}</a></h3>
-                        <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
-                    </li>
-                    {% endfor %}
-                </ul>
+            {% for item in insights_feed %}
+            <div class="three-col {% if forloop.last %}last-col no-margin-bottom{% endif %}">
+                <h3><a href="{{ item.link }}">{{ item.title }}</a></h3>
+                <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
             </div>
+            {% endfor %}
+        </div>
+        <div class="three-col no-margin-bottom last-col equal-height--vertical-divider__item">
+            <h2 class="external row--ubuntu-news__title"><span><a href="https://insights.ubuntu.com/tag/spotlight/">Spotlight</a></span></h2>
+            {% for item in spotlight_feed %}
+            <div class="three-col {% if forloop.last %}last-col{% endif %}">
+                <h3><a href="{{ item.link }}">{{ item.title }}</a></h3>
+                <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
+            </div>
+            {% endfor %}
         </div>
     </div>
 </section>

--- a/webapp/lib/feeds.py
+++ b/webapp/lib/feeds.py
@@ -40,7 +40,7 @@ def get_json_feed_content(url, offset=0, limit=None):
     return content[offset:end]
 
 
-def get_rss_feed_content(url, offset=0, limit=None):
+def get_rss_feed_content(url, offset=0, limit=None, exclude_items_in=None):
     """
     Get the entries from an RSS feed
     """
@@ -58,6 +58,10 @@ def get_rss_feed_content(url, offset=0, limit=None):
             )
         )
         content = []  # Empty response
+
+    if exclude_items_in:
+        exclude_ids = [x['guid'] for x in exclude_items_in]
+        content = filter(lambda x: x['guid'] not in exclude_ids, content)
 
     content = content[offset:end]
     for item in content:


### PR DESCRIPTION
## Done

 - Added spotlight article support to the homepage news box
 - Added a way to exclude results from a get_rss_feed_content call (to allow removal of spotlight articles from the general feed, avoiding duplication)
- Added GTM tracking onclicks

## QA

Go to the homepage and see that three general articles and the one article tagged "spotlight" are pulled in from insights.

Check the page in all viewports.

Extra-credit: try using different feeds in index.html (lines 13-14) and check that they behave as expected (removing duplicates, etc.)