### PR TITLE
Updated Iot overview core logo

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -88,7 +88,7 @@
         <div class="five-col equal-height__item equal-height__align-vertically not-for-small">
             <img src="{{ ASSET_SERVER_URL }}805f2b3a-core_black-orange_st_hex.svg" alt="" width="200" />
         </div>
-        <div class="seven-col last-col equal-height__item">
+        <div class="five-col last-col equal-height__item">
             <h2>Snaps for security</h2>
             <p>Ubuntu Core is an all-snap version of Ubuntu.  A snap is a secure, easily upgraded, universal Linux package for an app and all its dependencies. Snaps are:</p>
             <ul class="list-ticks--compact">

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -23,7 +23,7 @@
         </div>
         <div class="six-col last-col">
             <div class="twelve-col">
-                <img src="{{ ASSET_SERVER_URL }}09424f4c-Logo-block.svg" alt="Company logos of companies who choose Ubuntu Core">
+                <img src="{{ ASSET_SERVER_URL }}5d324631-Logo-block.svg" alt="Company logos of companies who choose Ubuntu Core">
             </div>
             <p class="muted-heading">Leading brands choose Ubuntu Core for security,&nbsp;apps&nbsp;and&nbsp;updates</p>
         </div>
@@ -85,7 +85,10 @@
 
 <section class="row">
     <div class="strip-inner-wrapper equal-height">
-        <div class="seven-col equal-height__item">
+        <div class="five-col equal-height__item equal-height__align-vertically not-for-small">
+            <img src="{{ ASSET_SERVER_URL }}805f2b3a-core_black-orange_st_hex.svg" alt="" width="200" />
+        </div>
+        <div class="seven-col last-col equal-height__item">
             <h2>Snaps for security</h2>
             <p>Ubuntu Core is an all-snap version of Ubuntu.  A snap is a secure, easily upgraded, universal Linux package for an app and all its dependencies. Snaps are:</p>
             <ul class="list-ticks--compact">
@@ -96,9 +99,6 @@
                 <li>Widely adopted by industry leaders</li>
             </ul>
             <p><a href="http://snapcraft.io/" class="external">Learn how to make a snap</a></p>
-        </div>
-        <div class="five-col last-col equal-height__item equal-height__align-vertically not-for-small">
-            <img src="{{ ASSET_SERVER_URL }}805f2b3a-core_black-orange_st_hex.svg" alt="" width="150" />
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done

 - swapped out the image on the hero
 - Enlarged and swapped the side of the image in the core row
- made the row five col per @joanasa89 

## QA

 - look at `/internet-of-things` in all viewports

