### PR TITLE
fix row height on phone overview

### DIFF
--- a/static/css/section/_phone.scss
+++ b/static/css/section/_phone.scss
@@ -21,12 +21,7 @@
 
     @media only screen and (min-width : $breakpoint-medium) {
       display: flex;
-      height: 68vw;
       margin: auto;
-    }
-
-    @media only screen and (min-width : $breakpoint-large) {
-      height: 56vw;
     }
   }
 
@@ -417,11 +412,13 @@
         background-repeat: no-repeat;
         background-size: cover;
         color: $white;
+        height: 68vw;
         min-height: 470px;
         padding-top: 60px;
       }
 
       @media only screen and (min-width : $breakpoint-large) {
+        height: 56vw;
         min-height: 571px;
       }
 


### PR DESCRIPTION
## Done

* fixed height of partners row on phone overview as height were added for developer page... I move the css to that row-shine instead

## QA

* look at /phone and see that the 'partners' section looks ok
* look at /phone/developers and see that 'Space for your content to shine' looks good

## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

before

![image](https://cloud.githubusercontent.com/assets/441217/20211841/4608b3f2-a7f8-11e6-8de9-a85f9ca6acbc.png)

after

![image](https://cloud.githubusercontent.com/assets/441217/20211876/7506b97e-a7f8-11e6-9632-a7636f1affb0.png)
