### PR TITLE
remove letter spacing in header of footer per Marcus request

### DIFF
--- a/static/css/section/_footer.scss
+++ b/static/css/section/_footer.scss
@@ -53,7 +53,6 @@ footer.global {
       text-transform: uppercase;
       color: $warm-grey;
       line-height: 1.5em;
-      letter-spacing: .05em;
       margin-bottom: 0;
       padding: .833333333em 10px;
     }


### PR DESCRIPTION
## Done

* remove letter spacing in the h2's in the footer per a request from Marcus

## QA

1. look at the footer and see there is no letter spacing


## Screenshots

before
![image](https://cloud.githubusercontent.com/assets/441217/20219074/785e6ff0-a81f-11e6-86d7-f5a83a6881b1.png)

after
![image](https://cloud.githubusercontent.com/assets/441217/20219079/8007006e-a81f-11e6-9599-50ab9f5c58ff.png)


