### PR TITLE
Fix contact form path

### DIFF
--- a/templates/cloud/openstack/managed-cloud/index.html
+++ b/templates/cloud/openstack/managed-cloud/index.html
@@ -22,7 +22,7 @@
             <div class="for-small" style="width: 10rem; margin: 1rem auto;"><img src="{{ ASSET_SERVER_URL }}a85abc9c-bootstack_hero_pictogram.svg" alt="Bootstrap illustration" /></div>
             <p class="intro">BootStack is a managed service where the world-class team at Canonical build and operate your OpenStack cloud either on-premises or hosted.</p>
             <p>You don’t need the in-house expertise to stand-up and scale your cloud. And, when you’re ready, we can hand over operational control.</p>
-            <p><a href="/cloud/managed-cloud/contact-us" class="button--primary">Schedule a demo</a></p>
+            <p><a href="/cloud/openstack/managed-cloud/contact-us" class="button--primary">Schedule a demo</a></p>
         </div>
         <div class="four-col last-col equal-height__item equal-height__align-vertically align-center not-for-small">
             <p><img src="{{ ASSET_SERVER_URL }}a85abc9c-bootstack_hero_pictogram.svg" alt="Bootstrap illustration" /></p>
@@ -119,7 +119,7 @@
         </div>
 
         <div class="twelve-col">
-            <p><a href="/cloud/managed-cloud/contact-us" class="button--primary">Schedule a demo</a></p>
+            <p><a href="/cloud/openstack/managed-cloud/contact-us" class="button--primary">Schedule a demo</a></p>
         </div>
     </div>
 </div>

--- a/templates/cloud/openstack/managed-cloud/index.html
+++ b/templates/cloud/openstack/managed-cloud/index.html
@@ -21,7 +21,7 @@
             <h1>BootStack &mdash; your managed cloud with no lock-in</h1>
             <div class="for-small" style="width: 10rem; margin: 1rem auto;"><img src="{{ ASSET_SERVER_URL }}a85abc9c-bootstack_hero_pictogram.svg" alt="Bootstrap illustration" /></div>
             <p class="intro">BootStack is a managed service where the world-class team at Canonical build and operate your OpenStack cloud either on-premises or hosted.</p>
-            <p>You don’t need the in-house expertise to stand-up and scale your cloud. And, when you’re ready, we can hand over operational control.</p>
+            <p>You don’t need in-house expertise to stand-up and scale your cloud. And, when you’re ready, we can hand over operational control.</p>
             <p><a href="/cloud/openstack/managed-cloud/contact-us" class="button--primary">Schedule a demo</a></p>
         </div>
         <div class="four-col last-col equal-height__item equal-height__align-vertically align-center not-for-small">

--- a/templates/cloud/openstack/managed-cloud/index.html
+++ b/templates/cloud/openstack/managed-cloud/index.html
@@ -21,7 +21,7 @@
             <h1>BootStack &mdash; your managed cloud with no lock-in</h1>
             <div class="for-small" style="width: 10rem; margin: 1rem auto;"><img src="{{ ASSET_SERVER_URL }}a85abc9c-bootstack_hero_pictogram.svg" alt="Bootstrap illustration" /></div>
             <p class="intro">BootStack is a managed service where the world-class team at Canonical build and operate your OpenStack cloud either on-premises or hosted.</p>
-            <p>You don’t need in-house expertise to stand-up and scale your cloud. And, when you’re ready, we can hand over operational control.</p>
+            <p>We provide the in-house expertise to stand-up and scale your cloud. And, when you&rsquo;re ready, we will hand over operational control.</p>
             <p><a href="/cloud/openstack/managed-cloud/contact-us" class="button--primary">Schedule a demo</a></p>
         </div>
         <div class="four-col last-col equal-height__item equal-height__align-vertically align-center not-for-small">


### PR DESCRIPTION
## Done

Fix managed cloud contact form path and change intro copy

## QA

Check that the path is now /cloud/openstack/managed-cloud/contact-us and not /cloud/managed-cloud/contact-us

Intro copy changed as per doc https://docs.google.com/document/d/1g38PPPhEP0Z66eM_gezfUyUwAr5e9vGfTHJDWV8gZlE/edit#