### PR TITLE
add contact-us stripe to /core

### DIFF
--- a/templates/core/contact-us.html
+++ b/templates/core/contact-us.html
@@ -3,7 +3,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-	{% include "templates/_nav_breadcrumb.html" with section_title="Core" page_title="Contact us"  %}
+  {% include "templates/_nav_breadcrumb.html" with section_title="Core" page_title="Contact us"  %}
 </div>
 {% endblock second_level_nav_items %}
 
@@ -12,12 +12,8 @@
     <div class="strip-inner-wrapper">
         <div class="eight-col">
             <h1>Contact us</h1>
-            <p>If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch.</p>
+            <p>If you are thinking about using Ubuntu Core to power your Internet of Things devices or anything thing else, please fill in your details below and a member of our team will get in touch.</p>
         </div>
-	</div>
-</section>
-<section class="row no-border strip-light">
-    <div class="strip-inner-wrapper">
         <div class="eight-col">
             <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
             <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>

--- a/templates/core/contact-us.html
+++ b/templates/core/contact-us.html
@@ -12,7 +12,7 @@
     <div class="strip-inner-wrapper">
         <div class="eight-col">
             <h1>Contact us</h1>
-            <p>If you are thinking about using Ubuntu Core to power your Internet of Things devices or anything thing else, please fill in your details below and a member of our team will get in touch.</p>
+            <p>If you are thinking about using Ubuntu Core to power your Internet of Things devices or anything else, please fill in your details below and a member of our team will get in touch.</p>
         </div>
         <div class="eight-col">
             <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -173,11 +173,28 @@
     </div>
 </section>
 
-<section class="row no-border row-grey">
-    <div class="strip-inner-wrapper">
-        <div class="eight-col">
+
+<section class="row row-grey no-border row--contactus">
+    <div class="strip-inner-wrapper equal-height">
+        <div class="three-col equal-height__item equal-height__align-vertically">
+            <img src="{{ ASSET_SERVER_URL }}0c16085c-network-equipment_2px.svg" alt="Ubuntu Core is cool ;-)" class="not-for-small"/>
+        </div>
+        <div class="nine-col last-col equal-height__item equal-height__align-vertically">
             <h2>Want to make your own Ubuntu Core device?</h2>
             <p><a href="http://docs.ubuntu.com/core/en/guides/build-device/image-building">Build a custom Ubuntu Core image&nbsp;&rsaquo;</a></p>
+        </div>
+    </div>
+</section>
+
+<section class="row row-cta no-border strip-light">
+    <div class="strip-inner-wrapper">
+        <div class="seven-col">
+            <h2>Let&rsquo;s work together</h2>
+            <p class="clear">Talk to us if you are thinking about using Ubuntu Core for your next project.</p>
+            <p><a href="/core/contact-us" class="button--primary">Get in touch</a></p>
+        </div>
+        <div class="five-col align-center not-for-small last-col">
+            <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="140" alt="" />
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done

* added a contact-us row to the /core page
* added a gateway illustration to the row above to make it more balanced
* cleaned up the whitepace on the contact-us page
* [DEMO](http://www.ubuntu.com-add-core-contact-us.demo.haus/core)

## QA

1. go to /core
2. see a new contact-us strip at the bottom following the [copy doc](https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit#)
3. see the ‘Want to make’ row has a gateway illustration
4. see that /core/contact-us looks more like the iot contact-us pages

## Issue / Card

[trello card](https://trello.com/c/sZ0T2DBL)

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/20434127/693e78ec-ad9e-11e6-87d5-95862fc478e8.png)
