### PR TITLE
Capitalise Linux on support plans-and-pricing

### DIFF
--- a/templates/support/plans-and-pricing.html
+++ b/templates/support/plans-and-pricing.html
@@ -17,7 +17,7 @@
     <div class="strip-inner-wrapper">
         <div class="seven-col">
             <h1>Plans and pricing</h1>
-            <p>Ubuntu offers the best economics of any commercially supported linux solution and the best community support. Canonical offers everything you need from fully managed clouds to training and support. We aim to be as easy and economical as possible to work with and that includes flexible pricing.</p>
+            <p>Ubuntu offers the best economics of any commercially supported Linux solution and the best community support. Canonical offers everything you need from fully managed clouds to training and support. We aim to be as easy and economical as possible to work with and that includes flexible pricing.</p>
         </div><!-- /.eight-col -->
         <div class="prepend-one four-col text-center priority-0 last-col">
             <img src="{{ ASSET_SERVER_URL }}544a9eb7-image-ubuntuadvantage.svg" alt="" width="378" height="180" class="priority-0" />


### PR DESCRIPTION
Updated the case of Linux on `/support/plans-and-pricing`, along with the [copydoc](https://docs.google.com/document/d/1R7FRZbfx_5YHFeZUD93HgT8RW4OCbbK4blOulB4D6EE/edit)

Fixes #1106