### PR TITLE
add developer row to /internet-of-things

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -184,6 +184,19 @@
     </div>
 </section>
 
+<section class="row strip-light">
+    <div class="strip-inner-wrapper">
+        <div class="eight-col">
+            <h2>Best for developers</h2>
+            <p>With Ubuntu Core, you can develop a packaged application on your laptop, then monetise it by publishing it directly to the snap store.</p>
+            <p><a class="external" href="https://developer.ubuntu.com/en/snappy/">Learn about developing with Ubuntu Core</a></p>
+        </div>
+        <div class="four-col align-center not-for-small last-col">
+            <img src="{{ ASSET_SERVER_URL }}527fbcef-picto-developer-warmgrey.svg" width="150" />
+        </div>
+    </div>
+</section>
+
 <section class="row row-cta no-border strip-light">
     <div class="strip-inner-wrapper">
         <div class="four-col align-center not-for-small">


### PR DESCRIPTION
## Done

* add a developer row back to the /internet-of-things overview
* [DEMO](http://www.ubuntu.com-iot-overview-dev-row.demo.haus/internet-of-things)

## QA

1. go to /internet-of-things
2. see a developer row near the bottom and compare with the [copy doc](https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit#)

## Issue / Card

[trello card](https://trello.com/c/O8KMUnrt)

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/20435641/c5d5908a-ada4-11e6-8e40-eb6c6c5f8ad7.png)
