### PR TITLE
update IoT contextual footer for newsletter

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -213,6 +213,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_devices_newsletter_signup" third_item="_iot_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
 
 {% endblock content %}

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -184,6 +184,19 @@
     </div>
 </section>
 
+<section class="row strip-light">
+    <div class="strip-inner-wrapper">
+        <div class="eight-col">
+            <h2>Best for developers</h2>
+            <p>With Ubuntu Core, you can develop a packaged application on your laptop, then monetise it by publishing it directly to the snap store.</p>
+            <p><a class="external" href="https://developer.ubuntu.com/en/snappy/">Learn about developing with Ubuntu Core</a></p>
+        </div>
+        <div class="four-col align-center not-for-small last-col">
+            <img src="{{ ASSET_SERVER_URL }}527fbcef-picto-developer-warmgrey.svg" width="150" />
+        </div>
+    </div>
+</section>
+
 <section class="row row-cta no-border strip-light">
     <div class="strip-inner-wrapper">
         <div class="four-col align-center not-for-small">

--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -176,7 +176,7 @@ feature amazing apps for advanced industrial intelligence.</p>
 </section>
 
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_devices_newsletter_signup" third_item="_iot_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
 
 {% endblock content %}
 


### PR DESCRIPTION
## Done

* both the overview and robotics pages where pointing to the devices newsletter on mailchimp, it should go to the new marketo iot one

## QA

1. go to /internet-of-things and see the newsletter in the contextual footer is the IoT one
2. go to /internet-of-things/robotics and see the newsletter in the contextual footer is the IoT one

## Issue / Card

[trello card](https://trello.com/c/Y2y4hO8x)