### PR TITLE
updated contextual footer

### DIFF
--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -161,6 +161,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_contact" second_item="_iot_webinars" third_item="_iot_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
 
 {% endblock content %}


### PR DESCRIPTION
## Done

* reset /iot/gateway contextual footer to the default (developer, newsletter, news) per the [copy doc](https://docs.google.com/document/d/1kq0SPv-PAIfL9nHGxgNDpHhr5OplE2iNaZZiqG4RT48/edit#)

## QA

1. go to /internet-of-things/gateways and see that it is as the copy doc suggests

## Issue / Card

Fixes #1108 