### PR TITLE
update iot/digital-signage contextual footer

### DIFF
--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -187,6 +187,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_contact" second_item="_iot_webinars" third_item="_iot_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_iot_developers" second_item="_iot_newsletter_signup" third_item="_iot_further_reading" %}
 
 {% endblock content %}

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -3,24 +3,19 @@
 <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
 
 <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1670">
-    <h3>IoT newsletter</h3>
-    <p>Receive regular updates from our IoT newsletter.</p>
+    <h3 class="contextual-footer__title">IoT newsletter</h3>
+    <p class="contextual-footer__text">Receive regular updates from our IoT newsletter.</p>
     <ul class="no-bullets">
-        <li  class="mktFormReq mktField">
-            <label for="Email" class="mktoLabel " >Your email address:</label>
+        <li  class="mktFormReq mktField contextual-footer__list">
+            <label for="Email" class="mktoLabel contextual-footer__text--label" >Your email address:</label>
             <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" >
-        </li>
-        <li  class="mktField">
-            <input type="hidden" name="utm_source" class="mktoField  mktoFormCol" value="" >
-        </li>
-        <li  class="mktField">
-            <input type="hidden" name="IoT_Newsletters__c" class="mktoField  mktoFormCol" value="True" >
         </li>
         <li  class="mktField">
             <button type="submit" class="mktoButton">Submit</button></span><input type="hidden" name="formid" class="mktoField " value="1670"><input type="hidden" name="lpId" class="mktoField " value="3229"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="//pages.ubuntu.com/Opt-In_IoTNewsletters.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
         </li>
     </ul>
-
+    <input type="hidden" name="utm_source" class="mktoField  mktoFormCol" value="" >
+    <input type="hidden" name="IoT_Newsletters__c" class="mktoField  mktoFormCol" value="True" >
     <input type="hidden" name="returnURL" value="http://ubunt.eu/i1jy52" />
     <input type="hidden" name="retURL" value="http://ubunt.eu/i1jy52" />
 </form>


### PR DESCRIPTION
## Done

* reset the footer on the digital signage page
* added the BEM styles to the iot newsletter signup contextual footer block

## QA

1. go to /internet-of-things/digital-signage and see the footer is the default per the [copy doc](https://docs.google.com/document/d/1kq0SPv-PAIfL9nHGxgNDpHhr5OplE2iNaZZiqG4RT48/edit#)

## Issue / Card

Fixes #1107 