### PR TITLE
text and grammar updates on managed-cloud

### DIFF
--- a/templates/cloud/openstack/managed-cloud/index.html
+++ b/templates/cloud/openstack/managed-cloud/index.html
@@ -1,7 +1,7 @@
 {% extends "cloud/base_cloud.html" %}
 {% load versioned_static  %}
 
-{% block title %}BootStack - Your managed cloud | Ubuntu{% endblock %}
+{% block title %}BootStack - your managed cloud | Ubuntu{% endblock %}
 
 {% block meta_description %}With BootStack, Canonical will build, support and manage your cloud for only $15 per host per day.{% endblock meta_description %}
 
@@ -78,7 +78,7 @@
                     <img class="grid-list__img" src="https://assets.ubuntu.com/v1/878af602-pictogram-virtualisation-orange-hex.svg" alt="">
                 </div>
                 <div class="no-margin-bottom">
-                    <h3>Easy network function virtualization</h3>
+                    <h3>Easy network function virtualisation</h3>
                 </div>
                 <p class="clear">Develop and test your VNFs before deploying them into a production OpenStack cloud.</p>
             </div>
@@ -203,7 +203,7 @@
         <div class="equal-height--vertical-divider__item four-col">
             <h3>BootStack Direct</h3>
             <p>Whereas a Hosted BootStack leaves the operations to us, BootStack Direct guarantees the operation of the cloud goes directly to you, including training and support for your staff. We will get your OpenStack cloud up and running in days, preparing your team to become OpenStack operations experts.</p>
-            <p><a class="external" href="https://ubuntu.cloud/wp-content/uploads/2016/02/e843/Datasheet_Bootstack_your_Big_Data_Cloud_2015_Alexia_WEB-AW.pdf">Download BootStack Direct brochure</a></p>
+            <p><a class="external" href="https://ubuntu.cloud/wp-content/uploads/2016/02/e843/Datasheet_Bootstack_your_Big_Data_Cloud_2015_Alexia_WEB-AW.pdf">Download the BootStack Direct brochure</a></p>
         </div>
         <div class="equal-height--vertical-divider__item four-col last-col">
             <h3>BootStack for Kubernetes</h3>
@@ -223,8 +223,8 @@
         </div>
 
         <div class="six-col last-col">
-            <p>See how PLUMgrid leverages BootStack to help enterprises and service providers operationalise their webscale OpenStack and Container cloud’s SDN deployments.</p>
-            <p><a class="external" href="https://pages.ubuntu.com/Secure-scale-and-simplify-your-cloud-deployments_webinar.html">Watch webinar on-demand</a></p>
+            <p>See how PLUMgrid leverages BootStack to help enterprises and service providers operationalise their webscale OpenStack and container cloud’s SDN deployments.</p>
+            <p><a class="external" href="https://pages.ubuntu.com/Secure-scale-and-simplify-your-cloud-deployments_webinar.html">Watch the webinar</a></p>
         </div>
     </div>
 </section>

--- a/templates/cloud/openstack/managed-cloud/index.html
+++ b/templates/cloud/openstack/managed-cloud/index.html
@@ -21,7 +21,7 @@
             <h1>BootStack &mdash; your managed cloud with no lock-in</h1>
             <div class="for-small" style="width: 10rem; margin: 1rem auto;"><img src="{{ ASSET_SERVER_URL }}a85abc9c-bootstack_hero_pictogram.svg" alt="Bootstrap illustration" /></div>
             <p class="intro">BootStack is a managed service where the world-class team at Canonical build and operate your OpenStack cloud either on-premises or hosted.</p>
-            <p>We provide the in-house expertise to stand-up and scale your cloud. And, when you&rsquo;re ready, we will hand over operational control.</p>
+            <p class="intro">We provide the in-house expertise to stand-up and scale your cloud. And, when you&rsquo;re ready, we will hand over operational control.</p>
             <p><a href="/cloud/openstack/managed-cloud/contact-us" class="button--primary">Schedule a demo</a></p>
         </div>
         <div class="four-col last-col equal-height__item equal-height__align-vertically align-center not-for-small">


### PR DESCRIPTION
## Done

* fixed the managed-cloud page per the [copy doc](https://docs.google.com/document/d/1g38PPPhEP0Z66eM_gezfUyUwAr5e9vGfTHJDWV8gZlE/edit)

## QA

1. go to /cloud/openstack/managed-cloud
2. The third block in "Your cloud, your site, our expertise" should say "virtualisation"
3. Add "the" in the "Download BootStack Direct brochure" link
4. Remove "on-demand" from last row link, add 'the'
5. Lowercase "containers" in last paragraph
6. The title tag of the page should be sentence case: "BootStack - your managed cloud"
7. see the row-hero uses .intro class for both paragraphs


## Issue / Card

Fixes #1103, #1104 

