### PR TITLE
remove text and link to scope roulette

### DIFF
--- a/templates/phone/features.html
+++ b/templates/phone/features.html
@@ -8,21 +8,21 @@
 
 {% block second_level_nav_items %}
    <div class="strip-inner-wrapper">
-	   {% include "templates/_nav_breadcrumb.html" with section_title="Phone" page_title="Features"  %}
+     {% include "templates/_nav_breadcrumb.html" with section_title="Phone" page_title="Features"  %}
    </div>
 {% endblock second_level_nav_items %}
 
 {% block content %}
 <div class="row row-hero no-border">
-	<div class="strip-inner-wrapper">
-	    <div class="for-mobile">
-	        <img src="{{ ASSET_SERVER_URL }}2c499edf-intro-row.jpg?w=480" alt="" />
-	    </div>
-	  	<div class="four-col append-eight">
-	  		<h1>Features</h1>
-	  		<p class="intro">Ubuntu&rsquo;s scopes give you related content on one screen, instead of hiding it behind different apps. So everything you look for in life is now right at your&nbsp;fingertips.</p>
-	  	</div><!-- /.four-col -->
-	</div><!-- /.strip-inner-wrapper -->
+  <div class="strip-inner-wrapper">
+      <div class="for-mobile">
+          <img src="{{ ASSET_SERVER_URL }}2c499edf-intro-row.jpg?w=480" alt="" />
+      </div>
+      <div class="four-col append-eight">
+        <h1>Features</h1>
+        <p class="intro">Ubuntu&rsquo;s scopes give you related content on one screen, instead of hiding it behind different apps. So everything you look for in life is now right at your&nbsp;fingertips.</p>
+      </div><!-- /.four-col -->
+  </div><!-- /.strip-inner-wrapper -->
 </div><!-- .row -->
 
 <div class="row no-border strip-light">
@@ -33,15 +33,13 @@
       <div class="five-col last-col">
          <h2>Introducing scopes</h2>
          <p>Ubuntu&rsquo;s scopes are like individual home screens for different kinds of content, giving you access to everything from movies and music to local services and social media, without having to go through individual apps.</p>
-         <p>Scope Roulette gives you a chance to learn more about scopes, and along the way there&rsquo;s the chance to win Ubuntu Phone related prizes.</p>
-         <p><a class="external" href="http://ubuntu-phone.eu/scopes">Play to learn more</a></p>
       </div>
    </div><!-- /.strip-inner-wrapper -->
 </div>
 
 <div class="row row--video no-border no-padding">
     <h2>See scopes in action</h2>
-	<div class="the-video"><div></div></div>
+  <div class="the-video"><div></div></div>
     <p class="video-link"><a href="https://www.youtube.com/watch?v=CsDFMIphtZk&amp;hd=1" class="show-video">Watch the video</a></p>
 </div><!-- /.row -->
 


### PR DESCRIPTION
## Done

* removed text and link to scope roulette

## QA

1. go to /phone/features
2. see that the ‘Introducing Scopes’ section no longer has a text and a link to http://ubuntu-phone.eu/scopes and follows the [copy doc](https://docs.google.com/document/d/1JedTUA9UyJitU9MCFKYR-q8KgjrnixA5INYPp0FGOaM/edit)


## Issue / Card

Fixes #1126