### PR TITLE
add updated MAAS screen to /cloud

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -175,6 +175,21 @@
   // @section /cloud overview
   &.cloud-home {
 
+    .row-maas {
+
+      @media only screen and (min-width : $breakpoint-medium) {
+        background-image: url('#{$asset-server}ee944209-screenshot-cloud_maas.png?w=800');
+        background-position: 100% 50%;
+        background-repeat: no-repeat;
+        background-size: 45%;
+      }
+
+      @media only screen and (min-width : $breakpoint-large) {
+        background-position: 130% 50%;
+        background-size: 55%;
+      }
+    }
+
     // news and events list on /cloud
     .newsevent { // DDD do we need this bespoke pattern for the /cloud news list?
 
@@ -367,7 +382,7 @@
   }
 
   // @subsection /cloud/training
-  &.cloud-training  {
+  &.cloud-training {
 
     .row-hero {
 


### PR DESCRIPTION
## Done

* adding updated MAAS screen to /cloud

## QA

1. go to /cloud ‘MAAS is Metal as a Service’ section
2. see the image looks good on M/L, and not visible on S

## Issue / Card

Fixes #980

## Screenshots

Medium

![image](https://cloud.githubusercontent.com/assets/441217/20455267/cd99065c-ae4f-11e6-8073-622689a5fd2d.png)


Large

![image](https://cloud.githubusercontent.com/assets/441217/20455263/bf645e92-ae4f-11e6-968b-43dc449d2b43.png)
