### PR TITLE
change x position of % label on pie chart

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -295,7 +295,7 @@
     .attr('dy', '0');
   labels.append('tspan')
     .text(function (d) {return '(' + d.count + '%)'})
-    .attr('x', function(d) { return d.left - getObjWidth(this) / 2; })
+    .attr('x', function(d) { return d.left - getObjWidth(this) / 4; })
     .attr('dy', '20');
 
   // FF/Opera does not support offsetWidth for tspan's. If undefined


### PR DESCRIPTION
## Done

* changed the x position of the tspan for the percent on the donut chart on /cloud

## QA

1. go to /cloud, while not centred, the labels are better

## Issue / Card

Fixes #978

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/20462210/5af777cc-af0e-11e6-9a76-7f22e6f9c6ef.png)
