### PR TITLE
fix homepage and desktop section for very high resolution monitors

### DIFF
--- a/static/css/_global-settings.scss
+++ b/static/css/_global-settings.scss
@@ -1,3 +1,4 @@
 $asset-server: "https://assets.ubuntu.com/v1/";
 $navigation-threshold: 1024px;
+$viewport-threshold: 1250px;
 /* usage: background: url(#{$asset-server}/backgrounds/background.jpg) no-repeat 0 0; */

--- a/static/css/_global-settings.scss
+++ b/static/css/_global-settings.scss
@@ -1,4 +1,4 @@
 $asset-server: "https://assets.ubuntu.com/v1/";
 $navigation-threshold: 1024px;
-$viewport-threshold: 1250px;
+$viewport-threshold: 1281px;
 /* usage: background: url(#{$asset-server}/backgrounds/background.jpg) no-repeat 0 0; */

--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -317,6 +317,10 @@
           margin-top: 30%;
           margin-bottom: -40px;
         }
+
+        @media only screen and (min-width : $viewport-threshold) {
+          margin-bottom: 40px;
+        }
       }
 
       .borderlands {
@@ -450,7 +454,7 @@
       }
 
       @media only screen and (min-width: $viewport-threshold) {
-        background-position: 60% center;
+        background-position: 80% center;
         background-size: 600px;
       }
     }
@@ -476,7 +480,7 @@
       }
 
       @media only screen and (min-width: $viewport-threshold) {
-        background-position: 300px -1050px;
+        background-position: 0 -315px;
       }
     }
 
@@ -490,7 +494,7 @@
       }
 
       @media only screen and (min-width: $viewport-threshold) {
-        background-size: 25%;
+        background-size: 50%;
       }
     }
   }
@@ -524,7 +528,7 @@
       }
 
       @media only screen and (min-width: $viewport-threshold) {
-        background-size: 25%;
+        background-size: 50%;
       }
     }
 
@@ -539,7 +543,7 @@
       }
 
       @media only screen and (min-width: $viewport-threshold) {
-        background-position: 60% center;
+        background-position: 70% center;
       }
     }
   }

--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -257,11 +257,6 @@
           right: 3vw;
           width: 50vw;
         }
-
-        @media only screen and (min-width: $viewport-threshold) {
-          background-position: 10% center;
-          background-size: 600px;
-        }
       }
     }
 
@@ -283,11 +278,6 @@
         background-image: url('#{$asset-server}d037640f-desktop.png?w=984');
         background-repeat: no-repeat;
         background-size: cover;
-      }
-
-      @media only screen and (min-width: $viewport-threshold) {
-        //reset to strip-dark
-        background-image: none;
       }
     }
 
@@ -431,11 +421,6 @@
           right: 3vw;
           width: 50vw;
         }
-
-        @media only screen and (min-width: $viewport-threshold) {
-          background-position: 10% center;
-          background-size: 600px;
-        }
       }
     }
 
@@ -578,11 +563,6 @@
           right: 3vw;
           width: 50vw;
         }
-
-        @media only screen and (min-width: $viewport-threshold) {
-          background-position: 10% center;
-          background-size: 600px;
-        }
       }
     }
 
@@ -629,11 +609,6 @@
           height: 85%;
           right: 3vw;
           width: 50vw;
-        }
-
-        @media only screen and (min-width: $viewport-threshold) {
-          background-position: 10% center;
-          background-size: 600px;
         }
       }
     }

--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -257,6 +257,11 @@
           right: 3vw;
           width: 50vw;
         }
+
+        @media only screen and (min-width: $viewport-threshold) {
+          background-position: 10% center;
+          background-size: 600px;
+        }
       }
     }
 
@@ -273,14 +278,21 @@
     }
 
     .row-web-browsing {
+
       @media only screen and (min-width: $breakpoint-medium) {
         background-image: url('#{$asset-server}d037640f-desktop.png?w=984');
         background-repeat: no-repeat;
         background-size: cover;
       }
+
+      @media only screen and (min-width: $viewport-threshold) {
+        //reset to strip-dark
+        background-image: none;
+      }
     }
 
     .row-videos {
+
       @media only screen and (min-width: $breakpoint-medium) {
         border-bottom: 0;
       }
@@ -291,8 +303,8 @@
       @media only screen and (min-width: $breakpoint-medium) {
         background-image: url('#{$asset-server}126ebaea-borderlands.jpg');
         background-repeat: no-repeat;
-        background-size: cover;
         background-position: 0 0 ;
+        background-size: cover;
         min-height: 488px;
         padding-bottom: 0;
       }
@@ -415,6 +427,11 @@
           right: 3vw;
           width: 50vw;
         }
+
+        @media only screen and (min-width: $viewport-threshold) {
+          background-position: 10% center;
+          background-size: 600px;
+        }
       }
     }
 
@@ -430,6 +447,11 @@
 
       @media only screen and (min-width: $breakpoint-large) {
         min-height: 457px;
+      }
+
+      @media only screen and (min-width: $viewport-threshold) {
+        background-position: 60% center;
+        background-size: 600px;
       }
     }
   }
@@ -452,6 +474,10 @@
         margin-top: 0;
         min-height: 574px;
       }
+
+      @media only screen and (min-width: $viewport-threshold) {
+        background-position: 300px -1050px;
+      }
     }
 
     .row-case-studies {
@@ -461,6 +487,10 @@
         background-repeat: no-repeat;
         background-size: 74%;
         background-position: center 30px;
+      }
+
+      @media only screen and (min-width: $viewport-threshold) {
+        background-size: 25%;
       }
     }
   }
@@ -485,21 +515,31 @@
     }
 
     .row-case-studies {
+
       @media only screen and (min-width: $breakpoint-medium) {
         background-image: url('#{$asset-server}5b74fa2a-map.jpg');
         background-position: center 0;
         background-repeat: no-repeat;
         background-size: 75%;
       }
+
+      @media only screen and (min-width: $viewport-threshold) {
+        background-size: 25%;
+      }
     }
 
     .row-security {
+
       @media only screen and (min-width: $breakpoint-medium) {
         background-image: url('#{$asset-server}99d49a7d-padlock-chain.png');
         background-position: 80% center;
         background-repeat: no-repeat;
         background-size: initial;
         min-height: 310px;
+      }
+
+      @media only screen and (min-width: $viewport-threshold) {
+        background-position: 60% center;
       }
     }
   }
@@ -533,6 +573,11 @@
           height: 85%;
           right: 3vw;
           width: 50vw;
+        }
+
+        @media only screen and (min-width: $viewport-threshold) {
+          background-position: 10% center;
+          background-size: 600px;
         }
       }
     }
@@ -580,6 +625,11 @@
           height: 85%;
           right: 3vw;
           width: 50vw;
+        }
+
+        @media only screen and (min-width: $viewport-threshold) {
+          background-position: 10% center;
+          background-size: 600px;
         }
       }
     }

--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -485,7 +485,6 @@ body.homepage .row--cloud-products {
   }
 
   @media only screen and (min-width: $viewport-threshold) {
-    background-position: 60% center;
     background-size: 600px;
   }
 }

--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -93,21 +93,21 @@ body.homepage {
   }
 
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     .number-one-for-cloud {
       position: relative;
     }
   }
 
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     .cookie-policy .wrapper {
-      width: 984px;
+      width: $breakpoint-large;
     }
   }
 }
 
 
-@media only screen and (min-width : 984px) {
+@media only screen and (min-width : $breakpoint-large) {
   .homepage {
     header.banner {
       margin-bottom: 5px;
@@ -118,7 +118,7 @@ body.homepage {
 .lang-switch-wrapper {
   padding-bottom: 0;
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     .five-col {
       padding-top: 0;
     }
@@ -129,7 +129,7 @@ body.homepage {
     }
   }
 
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     .five-col {
       padding-top: 0;
     }
@@ -161,7 +161,7 @@ body.homepage {
   }
 }
 
-@media only screen and (min-width : 984px) {
+@media only screen and (min-width : $breakpoint-large) {
   .ubuntu-intro__list {
     position: relative;
 
@@ -180,7 +180,7 @@ body.homepage {
   }
 }
 
-@media only screen and (max-width : 768px) {
+@media only screen and (max-width : $breakpoint-medium) {
   .ubuntu-intro__list:before {
     display: none;
   }
@@ -198,7 +198,7 @@ body.homepage {
 
 .intro-left,
 .intro-right {
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     background: url('#{$asset-server}bcb69486-image-intro-dots.svg') repeat-x right center;
     background-size: 10px;
   }
@@ -228,7 +228,7 @@ body.homepage {
   position: relative;
   width: 50%;
 
-  @media only screen and (max-width : 768px) {
+  @media only screen and (max-width : $breakpoint-medium) {
     width: 32%;
   }
 
@@ -236,12 +236,12 @@ body.homepage {
     width: 20%;
   }
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     text-indent: -999em;
     width: 121px;
   }
 
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     width: 164px;
   }
 }
@@ -260,7 +260,7 @@ body.homepage {
   position: relative;
   width: 100%;
 
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     &:before,
     &:after {
       display: block;
@@ -379,7 +379,7 @@ body.homepage .row--intro .intro-middle li a:hover {
   }
 }
 
-@media only screen and (max-width : 768px) {
+@media only screen and (max-width : $breakpoint-medium) {
   .row--devices {
     min-height: 0;
   }
@@ -388,12 +388,12 @@ body.homepage .row--intro .intro-middle li a:hover {
 body.homepage .row--ubuntu-news {
   background-color: #fff;
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     margin-bottom: 0px;
     padding-top: 60px;
   }
 
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     padding-top: 70px;
   }
 
@@ -402,7 +402,7 @@ body.homepage .row--ubuntu-news {
     z-index: 2;
   }
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     .row--ubuntu-news__title {
       background: url('#{$asset-server}e1bba201-external-link-cool-grey.svg') left center no-repeat;
       background-size: 16px;
@@ -438,7 +438,7 @@ body.homepage .row--iot {
   overflow: hidden;
   background: #fff;
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     padding: 150px 0;
   }
 
@@ -452,7 +452,7 @@ body.homepage .row--iot {
     top: -100px;
     width: 700px;
 
-    @media only screen and (min-width : 768px) {
+    @media only screen and (min-width : $breakpoint-medium) {
     top: -163px;
 
     }
@@ -470,7 +470,7 @@ body.homepage .row--iot {
 body.homepage .row--cloud-products {
   background-color: #fff;
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     background-image: url('#{$asset-server}890dec32-cloud-laptop.jpg?w=792');
     background-repeat: no-repeat;
     background-position: 77% center;
@@ -479,9 +479,14 @@ body.homepage .row--cloud-products {
     padding-bottom: 100px;
   }
 
-  @media only screen and (min-width: 984px) {
-    padding-top: 180px;
+  @media only screen and (min-width: $breakpoint-large) {
     padding-bottom: 170px;
+    padding-top: 180px;
+  }
+
+  @media only screen and (min-width: $viewport-threshold) {
+    background-position: 60% center;
+    background-size: 600px;
   }
 }
 
@@ -495,7 +500,7 @@ body.homepage .row--devices__inner {
   min-height: 460px;
   position: relative;
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     min-height: 280px;
   }
 
@@ -514,7 +519,7 @@ body.homepage .row--devices__inner {
 #devices {
   margin: 180px auto 0;
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     margin-top: 20px;
   }
 }
@@ -627,13 +632,13 @@ $shark: #181c21; // http://chir.ag/projects/name-that-color/#181C21
 // ============================ Takeovers ============================
 // cloud default, don not remove
 body.homepage-cloud-default {
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     h1 {
       padding-top: 90px;
     }
   }
 
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     .row-popular-cloud {
       padding-top: 80px;
       padding-top: 80px;
@@ -642,7 +647,7 @@ body.homepage-cloud-default {
     h1 {
       padding-top: 105px;
     }
-  } // @media only screen and (min-width : 984px)
+  } // @media only screen and (min-width : $breakpoint-large)
 } // body.homepage-cloud-default
 
 
@@ -661,7 +666,7 @@ body.homepage-cloud-default {
     }
   }
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     header.banner {
       -moz-box-shadow: none;
       -webkit-box-shadow: none;
@@ -701,7 +706,7 @@ body.homepage-cloud-default {
     }
   }
 
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     #main-content .row-hero {
       margin-top: -53px;
       min-height: 615px;
@@ -726,7 +731,7 @@ body.homepage-15-10 {
       overflow: hidden;
       padding-bottom: 0;
 
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         background: url('#{$asset-server}8d298549-home-takeover-.jpg?w=1800&q=80') 50% 50% no-repeat;
         background-size: cover;
         color: $cool-grey;
@@ -742,7 +747,7 @@ body.homepage-15-10 {
       }
 
       h1 {
-          @media only screen and (min-width : 768px) {
+          @media only screen and (min-width : $breakpoint-medium) {
             margin-top: 50px;
           }
 
@@ -787,7 +792,7 @@ body.homepage.meizu-takeover {
     margin-left: 0;
   }
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     .lang-switch {
       padding: 0;
     }
@@ -816,7 +821,7 @@ body.homepage.meizu-takeover {
     }
   }
 
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     #main-content .row-hero {
       padding-top: 7%;
     }
@@ -825,7 +830,7 @@ body.homepage.meizu-takeover {
 
 .homepage-autopilot #main-content .row-hero .twelve-col {
   margin-top: 30px;
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     margin-top: 40px;
   }
 }
@@ -867,13 +872,13 @@ body.homepage.meizu-takeover {
       min-height: auto;
     }
 
-    @media only screen and (min-width : 768px) {
+    @media only screen and (min-width : $breakpoint-medium) {
       background-position: 60% 130px;
       min-height: 550px;
       padding-top: 60px;
     }
 
-    @media only screen and (min-width : 984px) {
+    @media only screen and (min-width : $breakpoint-large) {
       background-position: 60% 200px;
       min-height: 600px;
     }
@@ -897,7 +902,7 @@ body.homepage-russia {
     }
 
     .row-hero {
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         margin-top: 0;
         overflow: hidden;
         padding-bottom: 0;
@@ -907,7 +912,7 @@ body.homepage-russia {
       }
 
       h1 {
-          @media only screen and (min-width : 768px) {
+          @media only screen and (min-width : $breakpoint-medium) {
             margin-top: 50px;
           }
 
@@ -959,7 +964,7 @@ body.juju-takeover {
         margin-top: 20px;
       }
 
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         margin-top: 0;
 
         .row-hero-text {
@@ -992,7 +997,7 @@ body.juju-takeover {
         }
       }
 
-      @media only screen and (min-width : 984px) {
+      @media only screen and (min-width : $breakpoint-large) {
 
         .row-hero-text {
           padding-left: 20px;
@@ -1040,12 +1045,12 @@ body.homepage-maas-takeover {
       padding-top: 40px;
       transition-duration: 1s;
 
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         min-height: 400px;
         padding-top: 40px;
       }
 
-      @media only screen and (min-width : 984px) {
+      @media only screen and (min-width : $breakpoint-large) {
         min-height: 455px;
         padding-top: 60px;
       }
@@ -1085,7 +1090,7 @@ body.homepage-maas-takeover {
       min-height: 50vw;
       position: relative;
 
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         min-height: 520px;
         padding-top: 160px;
       }
@@ -1172,7 +1177,7 @@ body.homepage-maas-takeover {
     margin-top: 0;
     overflow: hidden;
 
-    @media only screen and (min-width : 768px) {
+    @media only screen and (min-width : $breakpoint-medium) {
       background-image: url('#{$asset-server}0a11c33e-meizu-pro5-background.png');
       padding-top: 30px;
     }
@@ -1181,7 +1186,7 @@ body.homepage-maas-takeover {
       min-height: 50vw;
       position: relative;
 
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         min-height: 550px;
 
         .row-hero-text {
@@ -1195,7 +1200,7 @@ body.homepage-maas-takeover {
         }
       }
 
-      @media only screen and (min-width : 984px) {
+      @media only screen and (min-width : $breakpoint-large) {
         min-height: 580px;
 
         .row-hero-text {
@@ -1217,13 +1222,13 @@ body.homepage-maas-takeover {
 
   &.index_kylin {
     #main-content .row-hero .strip-inner-wrapper {
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         .row-hero-text {
           margin-top: 180px;
         }
       }
 
-      @media only screen and (min-width : 984px) {
+      @media only screen and (min-width : $breakpoint-large) {
         .row-hero-text {
           margin-top: 165px;
         }
@@ -1250,7 +1255,7 @@ body.homepage-maas-takeover {
     overflow: hidden;
     padding-top: 30px;
 
-    @media only screen and (min-width : 768px) {
+    @media only screen and (min-width : $breakpoint-medium) {
       background-image: url('#{$asset-server}52fbb3e9-hero-background-lg.jpg');
       background-position: center center;
       padding-top: 30px;
@@ -1261,7 +1266,7 @@ body.homepage-maas-takeover {
       overflow: visible;
       position: relative;
 
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         background: url('#{$asset-server}ff61f48c-hero-tablet-2x.png?w=440') 0 50px no-repeat;
         min-height: 400px;
 
@@ -1274,7 +1279,7 @@ body.homepage-maas-takeover {
         padding-top: 20px;
       }
 
-      @media only screen and (min-width : 984px) {
+      @media only screen and (min-width : $breakpoint-large) {
         background: url('#{$asset-server}ff61f48c-hero-tablet-2x.png?w=630') -30px 100px no-repeat;
         min-height: 630px;
 
@@ -1287,7 +1292,7 @@ body.homepage-maas-takeover {
 }
 
 #main-content .row-hero.china {
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     h1 {
       font-size: 2.4em;
     }
@@ -1309,7 +1314,7 @@ body.homepage-maas-takeover {
   padding-top: 10px;
   width: auto;
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     background-image: url('https://assets.ubuntu.com/v1/34ab80ea-image-background-16-04.jpg');
     background-size: cover;
     margin: 20px;
@@ -1341,7 +1346,7 @@ body.homepage-maas-takeover {
     font-size: 2em;
   }
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     &__title {
       font-size: 3em;
       margin-top: 6vh;
@@ -1352,7 +1357,7 @@ body.homepage-maas-takeover {
     }
   }
 
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     &__title {
       font-size: 3.5em;
       line-height: 1.8;
@@ -1407,13 +1412,13 @@ body.homepage-maas-takeover {
     margin-top: 20px;
     width: 60px;
 
-    @media only screen and (min-width : 768px + 1) {
+    @media only screen and (min-width : $breakpoint-medium + 1) {
       margin-top: 80px;
       width: 100px;
     }
   }
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     background-size: cover;
     margin: 20px;
     min-height: 380px;
@@ -1433,12 +1438,12 @@ body.homepage-maas-takeover {
   }
 
   &__text {
-    @media only screen and (min-width : 768px) {
+    @media only screen and (min-width : $breakpoint-medium) {
       margin-left: 2vw;
       width: 40.37611%;
     }
 
-    @media only screen and (min-width : 984px) {
+    @media only screen and (min-width : $breakpoint-large) {
       margin-left: 8.5177%;
       width: 31.8584%;
     }
@@ -1448,14 +1453,14 @@ body.homepage-maas-takeover {
     margin: 0 auto;
   }
 
-  @media only screen and (min-width : 768px) {
+  @media only screen and (min-width : $breakpoint-medium) {
     &__title {
       margin-top: 4vh;
       margin-left: 2vw;
     }
   }
 
-  @media only screen and (min-width : 984px) {
+  @media only screen and (min-width : $breakpoint-large) {
     min-height: 550px;
 
     &__title {
@@ -1506,7 +1511,7 @@ body.homepage-bootstack-generic {
       background-color: transparent;
     }
 
-    @media only screen and (min-width : 768px) {
+    @media only screen and (min-width : $breakpoint-medium) {
       h1 {
         padding-top: 45px;
       }
@@ -1517,7 +1522,7 @@ body.homepage-bootstack-generic {
       }
     }
 
-    @media only screen and (min-width : 984px) {
+    @media only screen and (min-width : $breakpoint-large) {
       h1 {
         padding-top: 55px;
       }
@@ -1549,12 +1554,12 @@ body.homepage-maas-generic-takeover {
       padding-top: 40px;
       transition-duration: 1s;
 
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         min-height: 400px;
         padding-top: 40px;
       }
 
-      @media only screen and (min-width : 984px) {
+      @media only screen and (min-width : $breakpoint-large) {
         min-height: 455px;
         padding-top: 60px;
       }
@@ -1603,14 +1608,14 @@ body.homepage-autopilot-devops-takeover {
         }
       }
 
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         background-size: cover;
         background-image: url('#{$asset-server}33f77842-openstack-autopilot-takeover.jpg?w=984');
         min-height: 45vw;
         padding-top: 10vw;
       }
 
-      @media only screen and (min-width : 984px) {
+      @media only screen and (min-width : $breakpoint-large) {
         background-image: url('#{$asset-server}33f77842-openstack-autopilot-takeover.jpg');
         min-height: 45vw;
         padding-top: 10vw;
@@ -1628,7 +1633,7 @@ body.homepage-autopilot-devops-takeover {
 body.homepage-linux-25th-takeover {
   #main-content {
     .row-hero {
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         min-height: 285px;
 
         .row-hero__heading {
@@ -1636,7 +1641,7 @@ body.homepage-linux-25th-takeover {
         }
       }
 
-      @media only screen and (min-width : 984px) {
+      @media only screen and (min-width : $breakpoint-large) {
         min-height: 350px;
 
         .row-hero__heading {
@@ -1671,7 +1676,7 @@ body.homepage-nextcloud-takeover {
         margin-bottom: 20px;
       }
 
-      @media only screen and (min-width : 768px) {
+      @media only screen and (min-width : $breakpoint-medium) {
         background-image: url('#{$asset-server}5aa79282-56f66029-Nextbox+09.2016.desktop.background-large.png');
         min-height: 440px;
 
@@ -1684,7 +1689,7 @@ body.homepage-nextcloud-takeover {
         }
       }
 
-      @media only screen and (min-width : 984px) {
+      @media only screen and (min-width : $breakpoint-large) {
         min-height: 540px;
 
         .row-hero__heading {

--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -468,25 +468,7 @@ body.homepage .row--iot {
 
 // row--cloud-products
 body.homepage .row--cloud-products {
-  background-color: #fff;
-
-  @media only screen and (min-width : $breakpoint-medium) {
-    background-image: url('#{$asset-server}890dec32-cloud-laptop.jpg?w=792');
-    background-repeat: no-repeat;
-    background-position: 77% center;
-    background-size: 50%;
-    padding-top: 100px;
-    padding-bottom: 100px;
-  }
-
-  @media only screen and (min-width: $breakpoint-large) {
-    padding-bottom: 170px;
-    padding-top: 180px;
-  }
-
-  @media only screen and (min-width: $viewport-threshold) {
-    background-size: 600px;
-  }
+  background-color: $white;
 }
 
 body.homepage .row--devices {

--- a/templates/index.html
+++ b/templates/index.html
@@ -69,7 +69,7 @@
             <p>With BootStack, we design, build and run your private cloud infrastructure without vendor lock-in.</p>
         </div>
         <div class="eight-col last-col">
-            <img class="for-small" src="{{ ASSET_SERVER_URL }}f27582be-image-cloud-static.jpg" alt="" />
+            <img src="{{ ASSET_SERVER_URL }}890dec32-cloud-laptop.jpg?w=792" />
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done

* created a $viewport-threshold at 1250px
* used a new media query at this level to resize and reposition the background images at large viewports
* drive-by - use variable names for media queries in the _homepage.scss
* [DEMO](http://www.ubuntu.com-970-scale-background-images.demo.haus)

## QA

1. go to the / homepage and the whole of the desktop section
2. use a high-res viewport or fake with browser and see that no images are either very large or very far off the screen

## Issue / Card

Fixes #970

## Screenshots

homepage

before
![image](https://cloud.githubusercontent.com/assets/441217/20463692/ddb128ee-af30-11e6-9e22-acf0008c9e52.png)

after
![image](https://cloud.githubusercontent.com/assets/441217/20463687/c757c774-af30-11e6-8bbc-d7c0fcb0f5c7.png)

/desktop/enterprise

before
![image](https://cloud.githubusercontent.com/assets/441217/20463700/084f4d42-af31-11e6-818f-d3ebf4aceafd.png)

after
![image](https://cloud.githubusercontent.com/assets/441217/20463705/146bdb54-af31-11e6-9015-dcd83dd26716.png)
