### PR TITLE
fix for display issues on takeunders at medium viewports

### DIFF
--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -513,6 +513,10 @@ body.homepage .row-featured {
   overflow: hidden;
 
   @media only screen and (min-width : $breakpoint-medium) {
+    margin: -100px 0 0;
+  }
+
+  @media only screen and (min-width : $breakpoint-large) {
     margin: -100px 0 -60px 0;
   }
 }


### PR DESCRIPTION
## Done

Fixed the display issue on medium screens

## QA

View the homepage takeunders at all viewports and contrast with live where they are broken.

[Screenshot](https://github.com/ubuntudesign/www.ubuntu.com/pull/1146#issuecomment-262782651)