### PR TITLE
make search form not wrap when zoomed in large screen

### DIFF
--- a/static/css/section/_navigation.scss
+++ b/static/css/section/_navigation.scss
@@ -101,6 +101,12 @@
         }
       }
     }
+
+    #site-search {
+      @media only screen and (min-width: $navigation-threshold) {
+        display: table-cell;
+      }
+    }
   }
 
   .search-toggle {


### PR DESCRIPTION
## Done

* made the search box div display: table-cell > the nav threshold so it doesn't wrap to a second line

## QA

1. go to any page and then zoom in
2. see that the search box doesn't drop down

## Issue / Card

Fixes #1144