### PR TITLE
update header on cloud newsletter form

### DIFF
--- a/templates/shared/contextual_footers/_cloud_contact_us.html
+++ b/templates/shared/contextual_footers/_cloud_contact_us.html
@@ -4,7 +4,7 @@
 
 <div class="box-digest">
     <form class='mktoForm mktoNoJS' action='https://pages.canonical.com/index.php/leadCapture/save' method='post'>
-        <h3 class="contextual-footer__title">Sign up for news updates</h3>
+        <h3 class="contextual-footer__title">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
         <ul class='contextual-footer__list mktoFormRow clearfix'>
             <li class='mktoFormCol'>
                 <label class="off-left mktoLabel" for='Email'>Your email</label>


### PR DESCRIPTION
## Done

* changed header from 'Sign up for news updates' to 'Sign up for our monthly Cloud Newsletter' 

## QA

1. go to /cloud and see the text change in the footer

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/20702719/f32a1500-b610-11e6-9c27-1e016e6d72fe.png)
