### PR TITLE
merge signposts to phone and tablet to point to mobile and update lin…

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -50,8 +50,7 @@
                     <li><a class="intro-cloud" href="/cloud">Cloud</a></li>
                     <li><a class="intro-server" href="/server">Server</a></li>
                     <li><a class="intro-desktop" href="/desktop">Desktop</a></li>
-                    <li><a class="intro-phone" href="/phone">Phone</a></li>
-                    <li><a class="intro-tablet" href="/tablet">Tablet</a></li>
+                    <li><a class="intro-phone" href="/mobile">Mobile</a></li>
                     <li><a class="intro-iot" href="/internet-of-things">IoT</a></li>
                 </ul>
             </div>
@@ -86,7 +85,7 @@
             </div>
         </div>
         <div class="row--devices__content four-col last-col">
-            <h2><a href="/phone">Multiple devices, one&nbsp;experience&nbsp;&rsaquo;</a></h2>
+            <h2><a href="/mobile">Multiple devices, one&nbsp;experience&nbsp;&rsaquo;</a></h2>
             <p>Ubuntu is a single software platform that runs across smartphones, tablets and PCs. It is designed to help make converged computing a reality: one system, one experience, multiple form factors.</p>
         </div>
     </div>


### PR DESCRIPTION
## Done

- updated signposts to merge phone and tablet into one called "mobile"
- updated link to /phone

## QA

Check the signpost on the homepage goes to /mobile as well as the link "Multiple devices, one experience ›"