### PR TITLE
remove reference to outdated openstack install guide

### DIFF
--- a/templates/cloud/openstack/index.html
+++ b/templates/cloud/openstack/index.html
@@ -106,33 +106,26 @@
 
 <section class="row row-grey">
     <div class="strip-inner-wrapper">
-        <h2 class="twelve-col">Four ways to get OpenStack on Ubuntu</h2>
+        <h2 class="twelve-col">Three ways to get OpenStack on Ubuntu</h2>
         <div class="equal-height">
-            <div class="equal-height__item six-col box">
+            <div class="equal-height__item four-col box">
                 <h3>Build your cloud</h3>
                 <p>OpenStack Autopilot is our fully automated tool for easy OpenStack deployment, management and operations.</p>
                 <p><a href="/download/cloud">Get Autopilot&nbsp;&rsaquo;
                 </a></p>
             </div>
-            <div class="equal-height__item six-col box last-col">
+            <div class="equal-height__item four-col box">
                 <h3>Buy a managed cloud</h3>
                 <p>With Bootstack, we will set up and operate an OpenStack cloud for you on your premises from only $15 per server.</p>
                 <p><a href="/cloud/openstack/managed-cloud">
                     Get BootStack&nbsp;&rsaquo;
                 </a></p>
             </div>
-            <div class="equal-height__item six-col box">
+            <div class="equal-height__item four-col last-col box">
                 <h3>Get a customised cloud</h3>
                 <p>Our engineers can tailor OpenStack to support your specific requirements and cloud applications</p>
                 <p><a href="/cloud/contact-us">
                     Contact us&nbsp;&rsaquo;
-                </a></p>
-            </div>
-            <div class="equal-height__item six-col box last-col">
-                <h3>Install OpenStack yourself</h3>
-                <p>If you prefer a manual setup of the latest OpenStack version, you can follow the instructions in our OpenStack operations guide.</p>
-                <p><a href="https://help.ubuntu.com/lts/clouddocs/en/Intro.html" class="external">
-                    Read the instructions
                 </a></p>
             </div>
         </div>


### PR DESCRIPTION
## Done

Removed an item from the openstack page

## QA

Check that the layout works at all viewports and matches the updated [copydoc](https://docs.google.com/document/d/12z6QEGpqMVbNPJOd5aUfn0VnXQ0Sa5YriEBLA7VGNwI/edit#)

## Issue / Card

Fixes #1165


