### PR TITLE
fix for overlapping text and images on the applications grid on the m…

### DIFF
--- a/static/css/section/_mobile.scss
+++ b/static/css/section/_mobile.scss
@@ -37,4 +37,10 @@
     background-color: #000;
     background-image: none;
   }
+
+  .row--applications .grid-list__img {
+    @media only screen and (min-width : $breakpoint-medium) {
+      max-width: 100%;
+    }
+  }
 }

--- a/static/css/section/_mobile.scss
+++ b/static/css/section/_mobile.scss
@@ -38,6 +38,45 @@
     background-image: none;
   }
 
+  .row--scopes {
+
+    @media only screen and (min-width : $breakpoint-medium) {
+      padding-left: 0 !important;
+    }
+
+    @media only screen and (min-width : $breakpoint-large) {
+      align-items: center;
+      display: flex;
+      min-height: 730px;
+    }
+
+    &:before {
+
+      @media only screen and (min-width : $breakpoint-medium) {
+        background: url('#{$asset-server}b6052399-scopes-tablet-portrait.png?w=890') center right no-repeat;
+        background-size: contain;
+        content: '';
+        height: 80%;
+        left: 4vw;
+        position: absolute;
+        top: 10%;
+        width: 48vw;
+      }
+
+      @media only screen and (min-width : $breakpoint-large) {
+        background-size: auto;
+        height: 500px;
+        left: 0;
+        top: 110px;
+        width: 50vw;
+      }
+    }
+
+    &__image {
+      margin: 10px 0;
+    }
+  }
+
   .row--applications .grid-list__img {
     @media only screen and (min-width : $breakpoint-medium) {
       max-width: 100%;

--- a/templates/mobile/features.html
+++ b/templates/mobile/features.html
@@ -68,7 +68,7 @@
     </div>
 </section>
 
-<section class="row strip-light">
+<section class="row strip-light row--applications">
     <div class="strip-inner-wrapper">
         <div class="eight-col">
             <h2>All your favourite applications</h2>

--- a/templates/mobile/features.html
+++ b/templates/mobile/features.html
@@ -55,13 +55,11 @@
     </div>
 </section>
 
-<section class="row strip-light">
+<section class="row strip-light row--scopes">
     <div class="strip-inner-wrapper">
-        <div class="seven-col">
-            <img src="{{ ASSET_SERVER_URL }}2c10be98-scopes-row-2x.png?w=500" alt="Various scopes on phones" />
-        </div>
-        <div class="five-col last-col">
+        <div class="five-col prepend-seven last-col">
             <h2>Introducing scopes</h2>
+            <img class="row--scopes__image for-small" src="{{ ASSET_SERVER_URL }}b6052399-scopes-tablet-portrait.png?w=480" alt="A selection of tablets displaying scopes" />
             <p>Ubuntu&rsquo;s scopes are like individual home screens for different kinds of content. </p>
             <p>They collect everything from movies, music, local services and social media, presenting it to you in one place without having to launch multiple apps.</p>
         </div>

--- a/templates/mobile/features.html
+++ b/templates/mobile/features.html
@@ -27,7 +27,7 @@
     </div>
 </section>
 
-<section class="row strip-light">
+<section class="row strip-light no-border">
     <div class="strip-inner-wrapper">
         <div class="seven-col">
             <h2>Convergence that just clicks</h2>
@@ -162,7 +162,7 @@
     </div>
 </section>
 
-<section class="row">
+<section class="row no-border">
     <div class="strip-inner-wrapper">
         <div class="six-col append-one">
             <h2>The Ubuntu Store</h2>


### PR DESCRIPTION
## Done

 - Small tweak to the display of the grid of app logos on the mobile features page
 - reused the tablet rather than phone style for the scopes row


## QA

Look at the /mobile/features in all viewports and take specific note on smaller medium viewports.