### PR TITLE
styling tweak for hardware enablement row and changephone links to mo…

### DIFF
--- a/static/css/section/_mobile.scss
+++ b/static/css/section/_mobile.scss
@@ -79,6 +79,16 @@
       margin-top: 60px;
     }
   }
+
+  .row-case-studies {
+    background-image: none;
+
+    &__intro {
+      @media only screen and (min-width : $breakpoint-medium) {
+        margin-bottom: 40px;
+      }
+    }
+  }
 }
 
 .mobile-developers {

--- a/templates/mobile/partners.html
+++ b/templates/mobile/partners.html
@@ -52,7 +52,7 @@ Ubuntu tablet, Ubuntu for tablets, Ubuntu Edition, Ubuntu, tablet Ubuntu, lightw
         <div class="five-col prepend-one last-col">
             <h2>Differentiate where it matters</h2>
             <p>Ubuntu allows you to control the entire service layer &mdash; the visual identity and the suite of digital life services &mdash; ensuring a consistent user experience. This gives you the opportunity to differentiate your handsets without fragmenting or forking the operating system. It&rsquo;s an opportunity to increase revenue that simply doesn&rsquo;t exist on other&nbsp;platforms.</p>
-            <p><a href="/phone/developers">Learn more about customising the experience&nbsp;&rsaquo;</a></p>
+            <p><a href="/mobile/developers">Learn more about customising the experience&nbsp;&rsaquo;</a></p>
         </div>
     </div>
 </section>
@@ -71,7 +71,7 @@ Ubuntu tablet, Ubuntu for tablets, Ubuntu Edition, Ubuntu, tablet Ubuntu, lightw
 
 <section class="row strip-dark row-case-studies no-border">
     <div class="strip-inner-wrapper">
-        <div class="eight-col">
+        <div class="eight-col row-case-studies__intro">
             <h2>Easier hardware enablement</h2>
             <p>Ubuntu&rsquo;s core system is based around a typical Android Board Support Package (BSP), so you don&rsquo;t need to invest in new ones. And we have teams based in Taipei, Shanghai, London, Beijing and Boston, who can engage with your engineering and factory operations.</p>
         </div>
@@ -94,7 +94,7 @@ Ubuntu tablet, Ubuntu for tablets, Ubuntu Edition, Ubuntu, tablet Ubuntu, lightw
                     <p><cite>Li Nan, VP at Meizu</cite></p>
                 </blockquote>
             </div>
-            <p><a href="/phone/features">Learn more about the Ubuntu features&nbsp;&rsaquo;</a></p>
+            <p><a href="/mobile/features">Learn more about the Ubuntu features&nbsp;&rsaquo;</a></p>
         </div>
     </div>
 </section>
@@ -103,7 +103,7 @@ Ubuntu tablet, Ubuntu for tablets, Ubuntu Edition, Ubuntu, tablet Ubuntu, lightw
     <div class="strip-inner-wrapper equal-height--vertical-divider">
         <div class="six-col equal-height--vertical-divider__item">
             <h2>Contact us</h2>
-            <p>Canonical partners with OEMs, Operators and resellers to build unique mobile and PC experiences based on Ubuntu.</p>
+            <p>Canonical partners with OEMs, operators and resellers to build unique mobile and PC experiences based on Ubuntu.</p>
             <p><a href="/mobile/contact-us">Contact us about being a partner&nbsp;&rsaquo;</a></p>
         </div>
         <div class="six-col last-col equal-height--vertical-divider__item">


### PR DESCRIPTION
## Done

 - updated some /phone links to /mobile
 - added some bespoke styling for the "Easier hardware enablement" row

## QA

 - check the `/mobile/partners` page in all viewports
 - check that no links go to old `/phone` URLs