### PR TITLE
add Landscape link to /support

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -121,7 +121,9 @@
                 <li class="last-item">Role-based access</li>
             </ul>
         </div>
-        <p class="eight-col"><a class="external" href="https://landscape.canonical.com/" alt="Learn more about Landscape">Learn more about Landscape</a></p>
+        <div class="eight-col">
+            <p><a class="external" href="https://landscape.canonical.com/" alt="Learn more about Landscape">Learn more about Landscape</a></p>
+        </div>
     </div>
 </section>
 

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -121,6 +121,7 @@
                 <li class="last-item">Role-based access</li>
             </ul>
         </div>
+        <p class="eight-col"><a class="external" href="https://landscape.canonical.com/" alt="Learn more about Landscape">Learn more about Landscape</a></p>
     </div>
 </section>
 


### PR DESCRIPTION
## Done

* added Landscape link to /support overview

## QA

1. go to /support and see there is a 'Learn more about Landscape' link in the 'Systems management tool: Landscape' section

## Issue / Card

[copy doc](https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/)

## Screenshots
 
![image](https://cloud.githubusercontent.com/assets/441217/21100893/4dabccf0-c06e-11e6-81c3-3813cdae264b.png)


