### PR TITLE
Update developer link on mobile overview

### DIFF
--- a/templates/mobile/index.html
+++ b/templates/mobile/index.html
@@ -104,7 +104,7 @@ Ubuntu phone, Ubuntu tablet, convergence, mobile, IoT, devices, Linux phone, Lin
                 <img src="{{ ASSET_SERVER_URL }}12b46991-apps-grid.png?w=480" width="320" alt="A selection of Ubuntu apps" />
             </div>
             <p>With Ubuntu, developers can use the SDK toolkit to write a single native app that runs on Ubuntu phone, tablet and PC. Developers have a choice of programming languages and tools to use that spans native QML and HTML5, plus comprehensive API support for Cordova and JavaScript application frameworks.</p>
-            <p><a href="/tablet/developers">Learn more about app development&nbsp;&rsaquo;</a></p>
+            <p><a href="/mobile/developers">Learn more about app development&nbsp;&rsaquo;</a></p>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done
- Updated the developer link on the mobile overview page

## QA
- Pull down this branch and run `make run`
- Go to http://127.0.0.1:8001/mobile
- Check that the link in the "Develop once for multiple form factors" section links to `/mobile/developers/

