### PR TITLE
Add meta tag to define Content-Secure-Policy

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -24,6 +24,7 @@
 <meta property="twitter:account_id" content="4503599627481511" />
 <meta name="google-site-verification" content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
 <meta name="theme-color" content="#E95420" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' https:">
 
 <!--[if IE]>
 <meta http-equiv="X-UA-Compatible" content="IE=8">


### PR DESCRIPTION
## Done

Added meta tag to define Content Security Policy so that local development can more accurately reflect the production environment.

## QA

Check code

## Issue / Card

Fixes: https://github.com/ubuntudesign/www.ubuntu.com/issues/1141
