### PR TITLE
Update the versions and link in the EOL page

### DIFF
--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -48,7 +48,7 @@
 		<p>The Ubuntu LTS enablement stacks provide newer kernel and X support for existing Ubuntu LTS releases. These can be installed manually, or are automatically shipped if installing from 12.04.2/14.04.2 and newer release media. These newer enablement stacks are meant for desktop and server, and even recommended for cloud or virtual images. The Ubuntu kernel support lifecycle is as follows:</p>
 	</div>
 	<div class="twelve-col">
-		<p><img src="{{ ASSET_SERVER_URL }}58b4ccee-kernel-release-eol-20160613.png" alt="" class="not-for-small" /></p>
+		<p><img src="{{ ASSET_SERVER_URL }}299d2531-kernel-release-eol-20161213.png" alt="" class="not-for-small" /></p>
 		<table class="for-small">
 			<thead>
 				<tr><th>Release</th><th>Released</th><th>End of life</th></tr>
@@ -63,7 +63,7 @@
 				<tr><td>Ubuntu 16.04.2 (v4.8)</td><td>Feb-2017</td><td>Aug-2017</td></tr>
 				<tr><td>Ubuntu 16.10</td><td>Oct-2016</td><td>Jul-2017</td></tr>
 				<tr><td>Ubuntu 16.04.1 (v4.4)</td><td>Aug-2016</td><td>Apr-2021</td></tr>
-				<tr><td>Ubuntu 14.04.5</td><td>Aug-2016</td><td>May-2019</td></tr>
+				<tr><td>Ubuntu 14.04.5 (v4.4)</td><td>Aug-2016</td><td>May-2019</td></tr>
 				<tr><td>Ubuntu 16.04.0 (v4.4)</td><td>Apr-2016</td><td>Apr-2021</td></tr>
 				<tr><td>Ubuntu 14.04.4 (v4.2)</td><td>Feb-2016</td><td>Aug-2016</td></tr>
 				<tr><td>Ubuntu 15.10 (v4.2)</td><td>Oct-2015</td><td>Oct-2015</td></tr>
@@ -96,16 +96,16 @@
 		<p>Canonical&rsquo;s Ubuntu Cloud archive allows users the ability to install newer releases of <a href="/cloud/openstack" class="external">Ubuntu OpenStack</a> on an Ubuntu Server as they become available up through the next Ubuntu LTS release. The Ubuntu OpenStack support lifecycle is as follows:</p>
 	</div>
 	<div class="twelve-col">
-		<p><img src="{{ ASSET_SERVER_URL }}3371cc40-openstack-release-eol-20160613.png" alt="" class="not-for-small" /></p>
+		<p><img src="{{ ASSET_SERVER_URL }}dd209641-openstack-release-eol-20161213.png" alt="" class="not-for-small" /></p>
 		<table class="for-small">
 			<thead>
 				<tr><th>Release</th><th>Released</th><th>End of life</th><th>Extended customer support</th></tr>
 			</thead>
 			<tbody>
-				<tr><td>OpenStack Q</td><td>Apr-2019</td><td>Apr-2024</td></tr>
+				<tr><td>OpenStack Queens</td><td>Apr-2019</td><td>Apr-2024</td></tr>
 				<tr><td>Ubuntu 18.04 LTS</td><td>Oct-2018</td><td>Oct-2023</td></tr>
-				<tr><td>OpenStack Q</td><td>Apr-2018</td><td>Apr-2021</td></tr>
-				<tr><td>OpenStack P</td><td>Oct-2017</td><td>Apr-2019</td></tr>
+				<tr><td>OpenStack Queens</td><td>Apr-2018</td><td>Apr-2021</td></tr>
+				<tr><td>OpenStack Pike</td><td>Oct-2017</td><td>Apr-2019</td></tr>
 				<tr><td>OpenStack Ocata</td><td>Apr-2017</td><td>Jan-2019</td><td>Aug-2019</td></tr>
 				<tr><td>OpenStack Newton</td><td>Oct-2016</td><td>Apr-2018</td></tr>
 				<tr><td>OpenStack Mitaka</td><td>Apr-2016</td><td>Apr-2021</td></tr>
@@ -126,7 +126,7 @@
 		</table>
 	</div>
 	<div class="eight-col">
-		<p>For more information on previous and upcoming Ubuntu OpenStack releases please see the <a href="https://wiki.ubuntu.com/ServerTeam/CloudArchive" class="external">Ubuntu Cloud Archive wiki page</a>.</p>
+		<p>For more information on previous and upcoming Ubuntu OpenStack releases please see the <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive" class="external">Ubuntu Cloud Archive wiki page</a>.</p>
 	</div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
## Done
- Updated OpenStack P to OpenStack Pike
- Updated OpenStack Q to OpenStack Queen
- Added (v4.4) to the kernel version for 14.04.5
- Updated the Ubuntu Cloud Archive wiki link at the bottom of the page
- Updated the Kernel and OpenStack chart images to match the version updates

## QA
- Pull this branch down and `make run`
- Go to http://127.0.0.1:8001/info/release-end-of-life
- Check the changes above are complete

## Screenshots
![release end of life ubuntu](https://cloud.githubusercontent.com/assets/1413534/21143878/57c70fc4-c140-11e6-8060-f86cac27be92.png)


