### PR TITLE
add a cotnact for for the mobile section

### DIFF
--- a/templates/mobile/contact-us.html
+++ b/templates/mobile/contact-us.html
@@ -1,25 +1,33 @@
 {% extends "mobile/base_mobile.html" %}
 
-{% block title %}Contact us | Ubuntu for mobile{% endblock %}
-
-{% block meta_description %}Ubuntu is the perfect operating system for manufacturers who want to build mobile devices for either the consumer or enterprise market. Ubuntu represents a remarkable opportunity for OEMs, content providers and app developers.{% endblock %}
-
-{% block meta_keywords %}
-Ubuntu phone, Ubuntu tablet, convergence, mobile, IoT, devices, Linux phone, Linux tablet, Laptop and tablet, hybrid tablet, hybrid laptop, laptop replacement, laptop replacement screens, laptop screen replacement, convertible laptop, 2 in 1 laptop, two in one laptop
-{% endblock %}
-
-{% block extra_body_class %}mobile-home{% endblock %}
+{% block title %}Contact us | Ubuntu for Phones and Tablets{% endblock %}
 
 {% block second_level_nav_items %}
-    <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Mobile" page_title="Overview"  %}
-    </div>
+<div class="strip-inner-wrapper">
+	{% include "templates/_nav_breadcrumb.html" with section_title="Mobile" page_title="Contact us" %}
+</div>
 {% endblock second_level_nav_items %}
 
 {% block content %}
-
-[PARTNERS]
-
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_phone_partners_developers" second_item="_devices_newsletter_signup" third_item="_phone_further_reading" %}
+<section class="row row-hero no-border no-margin-bottom no-padding-bottom strip-light">
+    <div class="strip-inner-wrapper">
+        {% include "shared/_client-contact-us-form.html" with h1="Contact us" intro_text="If you are thinking about partnering with Ubuntu to power your mobile devices, please fill in your details below and a member of our team will get in touch." formid="1371" lpId="2436" returnURL="https://www.ubuntu.com/mobile/thank-you" %}
+        </div>
+    </div>
+</section>
 
 {% endblock content %}
+
+{% block footer_extra %}
+<script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
+<script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
+<script>
+  $("#mktoForm").validate({
+    errorElement: "span",
+    errorClass: "mktFormMsg mktError",
+    onkeyup: false,
+    onclick: false,
+    onblur: false
+  });
+</script>
+{% endblock footer_extra %}

--- a/templates/mobile/thank-you.html
+++ b/templates/mobile/thank-you.html
@@ -1,0 +1,47 @@
+{% extends "mobile/base_mobile.html" %}
+
+{% block title %}Thank you | Ubuntu for Phones and Tablets{% endblock %}
+
+{% block second_level_nav_items %}
+<div class="strip-inner-wrapper">
+    {% include "templates/_nav_breadcrumb.html" with section_title="Mobile" subsection_title="Contact us" page_title="Thank you" %}
+</div>
+{% endblock second_level_nav_items %}
+
+{% block content %}
+<div class="row row-hero no-border no-padding-bottom">
+    <div class="strip-inner-wrapper">
+        <div class="thank-you eight-col">
+            <h1>Thank you for enquiring about Ubuntu for Phones and Tablets</h1>
+            <p class="intro">A member of our team will be in touch within one working day</p>
+        </div>
+        <div class="four-col last-col">
+            <img src="{{ ASSET_SERVER_URL }}52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />
+        </div>
+    </div>
+</div>
+
+{% include "shared/_thank_you_footer.html" %}
+
+{% endblock content %}
+{% block footer_extra %}
+<!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
+<script type="text/javascript">
+/* <![CDATA[ */
+var google_conversion_id = 1012391776;
+var google_conversion_language = "en";
+var google_conversion_format = "3";
+var google_conversion_color = "ffffff";
+var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
+var google_conversion_value = 0;
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+</script>
+<noscript>
+<div style="display:inline;">
+<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+</div>
+</noscript>
+{{ marketo }}
+{% endblock footer_extra %}

--- a/templates/shared/_thank_you_footer.html
+++ b/templates/shared/_thank_you_footer.html
@@ -1,5 +1,5 @@
 <div class="row equal-height no-border strip-light">
-  {% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" or level_1 == "core" %}<div class="strip-inner-wrapper">{% endif %}
+  {% if level_1 == "mobile" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" or level_1 == "core" %}<div class="strip-inner-wrapper">{% endif %}
 	<h2 class="twelve-col">More about our enterprise services</h2>
 	<ul id="thank-you-extra" class="no-bullets">
 		<li class="advantage four-col first">
@@ -18,5 +18,5 @@
 			<p><a href="/support">Learn about Landscape&nbsp;&rsaquo;</a></p>
 		</li>
 	</ul>
-	{% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" or level_1 == "core" %}</div>{% endif %}
+	{% if level_1 == "mobile" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" or level_1 == "core" %}</div>{% endif %}
 </div><!-- end row-->


### PR DESCRIPTION
## Done

Added a contact us form for the mobile section - it's a copy of the old tablet form with updated copy.

## QA

Check /mobile/contact-us and /mobile/thank-you at all viewports (no copydoc but uses existing boilerplate wording)
