### PR TITLE
correct captialisation for Ubuntu Mobile in the contextual footer

### DIFF
--- a/templates/mobile/partners.html
+++ b/templates/mobile/partners.html
@@ -114,6 +114,6 @@ Ubuntu tablet, Ubuntu for tablets, Ubuntu Edition, Ubuntu, tablet Ubuntu, lightw
     </div>
  </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_phone_partners_developers" second_item="_devices_newsletter_signup" third_item="_phone_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_mobile_partners_developers" second_item="_devices_newsletter_signup" third_item="_phone_further_reading" %}
 
 {% endblock content %}

--- a/templates/shared/contextual_footers/_mobile_partners_developers.html
+++ b/templates/shared/contextual_footers/_mobile_partners_developers.html
@@ -1,4 +1,4 @@
 <h3 class="contextual-footer__title">A new opportunity</h3>
-<p class="contextual-footer__text">Mobile carriers, device makers and developers: start building your Ubuntu mobile experiences today.</p>
+<p class="contextual-footer__text">Mobile carriers, device makers and developers: start building your Ubuntu Mobile experiences today.</p>
 <p class="contextual-footer__text"><a href="/mobile/partners" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'mobile partners page', 'eventLabel' : 'New opportunity', 'eventValue' : undefined });">For carriers and OEMs</a></p>
 <p class="contextual-footer__text"><a href="/mobile/developers" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'mobile developers page', 'eventLabel' : 'New opportunity', 'eventValue' : undefined });">For mobile developers</a></p>


### PR DESCRIPTION
## Done

Corrected a typo "Ubuntu mobile" -> "Ubuntu Mobile"

## QA

Go to /mobile/partners and see that the left-hand contextual footer item is now correctly capitalised.
