### PR TITLE
update /cloud overview per Tom C

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -174,166 +174,191 @@
   }
 
   // @section /cloud overview
+  $animation-viewport: 900px;
+
   &.cloud-home {
 
     .row-hero {
-      .products-hero-container {
-        background: url('#{$asset-server}79729d72-products-hero-background.png') no-repeat;
-        height: 550px;
-        position: absolute;
-        right: 60px;
-        top: -20px;
-        width: 600px;
+      @media only screen and (min-width : $animation-viewport) {
+        min-height: 550px;
       }
 
-      .cloud-tools-list span,
-      .cloud-tools-list a {
-        -moz-animation: scaleInPop 0.2s forwards, fadeIn 0.2s linear forwards;
-        -webkit-animation: scaleInPop 0.2s forwards, fadeIn 0.2s linear forwards;
-        animation: scaleInPop 0.2s forwards, fadeIn 0.2s linear forwards;
-        background: url('#{$asset-server}73006c5b-products-hero-phone.svg') no-repeat;
-        background-size: 66px 66px;
-        height: 66px;
-        opacity: 0;
-        position: absolute;
-        text-indent: -999em;
-        width: 66px;
+      .strip-inner-wrapper {
+        position: relative;
+      }
 
-        &.item-line {
-          -moz-animation: fadeIn 0.3s linear forwards;
-          -webkit-animation: fadeIn 0.3s linear forwards;
-          animation: fadeIn 0.3s linear forwards;
-          content: ' ';
+      .cloud-tools {
+        display: none;
+
+        @media only screen and (min-width : $animation-viewport) {
           display: block;
+          left: 0;
           position: absolute;
-        }
+          top: -30px;
+          width: 100%;
 
-        &.item-one {
-          -moz-animation-delay: 1.6s;
-          -webkit-animation-delay: 1.6s;
-          animation-delay: 1.6s;
-          background-image: url('#{$asset-server}a7916513-picto-openstack.svg');
-          left: 357px;
-          top: 55px;
-        }
+          &__container {
+            background: url('#{$asset-server}79729d72-products-hero-background.png') no-repeat;
+            height: 550px;
+            position: absolute;
+            right: 20px;
+            top: -10px;
+            width: 606px;
 
-        &.item-one-line,
-        &.item-four-line {
-          -moz-animation-delay: 1.85s;
-          -webkit-animation-delay: 1.85s;
-          animation-delay: 1.85s;
-          background: url('#{$asset-server}ec446611-partners-hero-line-vertical.png');
-          height: 52px;
-          left: 387px;
-          top: 137px;
-          width: 2px;
-        }
+            @media only screen and (min-width : $breakpoint-large) {
+              right: 0;
+            }
+          }
 
-        &.item-two {
-          -moz-animation-delay: 1.85s;
-          -webkit-animation-delay: 1.85s;
-          animation-delay: 1.85s;
-          background-image: url('#{$asset-server}999949f8-picto-startfirst-midaubergine.svg');
-          left: 484px;
-          top: 108px;
-        }
+          &__item {
+            -moz-animation: scaleInPop 0.2s forwards, fadeIn 0.2s linear forwards;
+            -webkit-animation: scaleInPop 0.2s forwards, fadeIn 0.2s linear forwards;
+            animation: scaleInPop 0.2s forwards, fadeIn 0.2s linear forwards;
+            background: url('#{$asset-server}73006c5b-products-hero-phone.svg') no-repeat;
+            background-size: 66px 66px;
+            height: 66px;
+            opacity: 0;
+            position: absolute;
+            text-indent: -999em;
+            width: 66px;
 
-        &.item-two-line,
-        &.item-five-line {
-          -moz-animation-delay: 2s;
-          -webkit-animation-delay: 2s;
-          animation-delay: 2s;
-          background: url('#{$asset-server}4fc1680b-partners-hero-line-diagonal.png');
-          height: 38px;
-          left: 445px;
-          top: 175px;
-          width: 38px;
-        }
+            &--line {
+              -moz-animation: fadeIn 0.3s linear forwards;
+              -webkit-animation: fadeIn 0.3s linear forwards;
+              animation: fadeIn 0.3s linear forwards;
+              content: ' ';
+              display: block;
+              position: absolute;
 
-        &.item-three {
-          -moz-animation-delay: 2s;
-          -webkit-animation-delay: 2s;
-          animation-delay: 2s;
-          background-image: url('#{$asset-server}60bd6cf1-picto-juju.svg');
-          left: 547px;
-          top: 245px;
-        }
+              &-one,
+              &-four {
+                -moz-animation-delay: 1.85s;
+                -webkit-animation-delay: 1.85s;
+                animation-delay: 1.85s;
+                background: url('#{$asset-server}ec446611-partners-hero-line-vertical.png');
+                height: 52px;
+                left: 387px;
+                top: 137px;
+                width: 2px;
+              }
 
-        &.item-three-line,
-        &.item-six-line {
-          -moz-animation-delay: 2.15s;
-          -webkit-animation-delay: 2.15s;
-          animation-delay: 2.15s;
-          background: url('#{$asset-server}d505cff1-partners-hero-line-horizontal.png');
-          height: 2px;
-          left: 469px;
-          top: 277px;
-          width: 52px;
-        }
+              &-two,
+              &-five {
+                -moz-animation-delay: 2s;
+                -webkit-animation-delay: 2s;
+                animation-delay: 2s;
+                background: url('#{$asset-server}4fc1680b-partners-hero-line-diagonal.png');
+                height: 38px;
+                left: 445px;
+                top: 175px;
+                width: 38px;
+              }
 
-        &.item-four {
-          -moz-animation-delay: 2.15s;
-          -webkit-animation-delay: 2.15s;
-          animation-delay: 2.15s;
-          background-image: url('#{$asset-server}261ad7cb-picto-maas.svg');
-          left: 367px;
-          top: 425px;
-        }
+              &-three,
+              &-six {
+                -moz-animation-delay: 2.15s;
+                -webkit-animation-delay: 2.15s;
+                animation-delay: 2.15s;
+                background: url('#{$asset-server}d505cff1-partners-hero-line-horizontal.png');
+                height: 2px;
+                left: 469px;
+                top: 277px;
+                width: 52px;
+              }
 
-        &.item-four-line {
-          -moz-animation-delay: 2.3s;
-          -webkit-animation-delay: 2.3s;
-          animation-delay: 2.3s;
-          left: 396px;
-          top: 347px;
-        }
+              &-four {
+                -moz-animation-delay: 2.3s;
+                -webkit-animation-delay: 2.3s;
+                animation-delay: 2.3s;
+                left: 396px;
+                top: 347px;
+              }
 
-        &.item-five {
-          -moz-animation-delay: 2.3s;
-          -webkit-animation-delay: 2.3s;
-          animation-delay: 2.3s;
-          background-image: url('#{$asset-server}50c0306d-image-picto-landscape.svg');
-          left: 226px;
-          top: 372px;
-        }
+              &-five {
+                -moz-animation-delay: 2.45s;
+                -webkit-animation-delay: 2.45s;
+                animation-delay: 2.45s;
+                left: 301px;
+                top: 328px;
+              }
 
-        &.item-five-line {
-          -moz-animation-delay: 2.45s;
-          -webkit-animation-delay: 2.45s;
-          animation-delay: 2.45s;
-          left: 301px;
-          top: 328px;
-        }
+              &-six {
+                -moz-animation-delay: 2.6s;
+                -webkit-animation-delay: 2.6s;
+                animation-delay: 2.6s;
+                left: 259px;
+                top: 273px;
+              }
+            }
 
-        &.item-six {
-          -moz-animation-delay: 2.45s;
-          -webkit-animation-delay: 2.45s;
-          animation-delay: 2.45s;
-          background-image: url('#{$asset-server}c986edab-picto-cloud-midaubergine-solid.svg');
-          left: 170px;
-          top: 245px;
-        }
+            &--one {
+              -moz-animation-delay: 1.6s;
+              -webkit-animation-delay: 1.6s;
+              animation-delay: 1.6s;
+              background-image: url('#{$asset-server}a7916513-picto-openstack.svg');
+              left: 357px;
+              top: 55px;
+            }
 
-        &.item-six-line {
-          -moz-animation-delay: 2.6s;
-          -webkit-animation-delay: 2.6s;
-          animation-delay: 2.6s;
-          left: 259px;
-          top: 273px;
-        }
+            &--two {
+              -moz-animation-delay: 1.85s;
+              -webkit-animation-delay: 1.85s;
+              animation-delay: 1.85s;
+              background-image: url('#{$asset-server}999949f8-picto-startfirst-midaubergine.svg');
+              left: 484px;
+              top: 108px;
+            }
 
-        &.item-seven {
-          -moz-animation: scaleIn 0.3s forwards, fadeIn 0.6s linear forwards, rotateIn 3.0s ease-out forwards;
-          -webkit-animation: scaleIn 0.3s forwards, fadeIn 0.6s linear forwards, rotateIn 3.0s ease-out forwards;
-          animation: scaleIn 0.3s forwards, fadeIn 0.6s linear forwards, rotateIn 3.0s ease-out forwards;
-          -moz-animation-delay: 1s;
-          -webkit-animation-delay: 1s;
-          animation-delay: 1s;
-          background: url('#{$asset-server}c4f35e06-partners-hero-ubuntu.svg') no-repeat;
-          left: 320px;
-          top: 198px;
-          height: 140px;
-          width: 140px;
+            &--three {
+              -moz-animation-delay: 2s;
+              -webkit-animation-delay: 2s;
+              animation-delay: 2s;
+              background-image: url('#{$asset-server}60bd6cf1-picto-juju.svg');
+              left: 547px;
+              top: 245px;
+            }
+
+            &--four {
+              -moz-animation-delay: 2.15s;
+              -webkit-animation-delay: 2.15s;
+              animation-delay: 2.15s;
+              background-image: url('#{$asset-server}261ad7cb-picto-maas.svg');
+              left: 367px;
+              top: 425px;
+            }
+
+            &--five {
+              -moz-animation-delay: 2.3s;
+              -webkit-animation-delay: 2.3s;
+              animation-delay: 2.3s;
+              background-image: url('#{$asset-server}50c0306d-image-picto-landscape.svg');
+              left: 226px;
+              top: 372px;
+            }
+
+            &--six {
+              -moz-animation-delay: 2.45s;
+              -webkit-animation-delay: 2.45s;
+              animation-delay: 2.45s;
+              background-image: url('#{$asset-server}c986edab-picto-cloud-midaubergine-solid.svg');
+              left: 170px;
+              top: 245px;
+            }
+
+            &--seven {
+              -moz-animation: scaleIn 0.3s forwards, fadeIn 0.6s linear forwards, rotateIn 3.0s ease-out forwards;
+              -webkit-animation: scaleIn 0.3s forwards, fadeIn 0.6s linear forwards, rotateIn 3.0s ease-out forwards;
+              animation: scaleIn 0.3s forwards, fadeIn 0.6s linear forwards, rotateIn 3.0s ease-out forwards;
+              -moz-animation-delay: 1s;
+              -webkit-animation-delay: 1s;
+              animation-delay: 1s;
+              background: url('#{$asset-server}c4f35e06-partners-hero-ubuntu.svg') no-repeat;
+              left: 320px;
+              top: 198px;
+              height: 140px;
+              width: 140px;
+            }
+          }
         }
       }
     }

--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -166,15 +166,177 @@
     &:hover,
     &:link,
     &:visited {
-      color: $cool-grey;
       -moz-box-shadow: none;
       -webkit-box-shadow: none;
       box-shadow: none;
+      color: $cool-grey;
     }
   }
 
   // @section /cloud overview
   &.cloud-home {
+
+    .row-hero {
+      .products-hero-container {
+        background: url('#{$asset-server}79729d72-products-hero-background.png') no-repeat;
+        height: 550px;
+        position: absolute;
+        right: 60px;
+        top: -20px;
+        width: 600px;
+      }
+
+      .cloud-tools-list span,
+      .cloud-tools-list a {
+        -moz-animation: scaleInPop 0.2s forwards, fadeIn 0.2s linear forwards;
+        -webkit-animation: scaleInPop 0.2s forwards, fadeIn 0.2s linear forwards;
+        animation: scaleInPop 0.2s forwards, fadeIn 0.2s linear forwards;
+        background: url('#{$asset-server}73006c5b-products-hero-phone.svg') no-repeat;
+        background-size: 66px 66px;
+        height: 66px;
+        opacity: 0;
+        position: absolute;
+        text-indent: -999em;
+        width: 66px;
+
+        &.item-line {
+          -moz-animation: fadeIn 0.3s linear forwards;
+          -webkit-animation: fadeIn 0.3s linear forwards;
+          animation: fadeIn 0.3s linear forwards;
+          content: ' ';
+          display: block;
+          position: absolute;
+        }
+
+        &.item-one {
+          -moz-animation-delay: 1.6s;
+          -webkit-animation-delay: 1.6s;
+          animation-delay: 1.6s;
+          background-image: url('#{$asset-server}a7916513-picto-openstack.svg');
+          left: 357px;
+          top: 55px;
+        }
+
+        &.item-one-line,
+        &.item-four-line {
+          -moz-animation-delay: 1.85s;
+          -webkit-animation-delay: 1.85s;
+          animation-delay: 1.85s;
+          background: url('#{$asset-server}ec446611-partners-hero-line-vertical.png');
+          height: 52px;
+          left: 387px;
+          top: 137px;
+          width: 2px;
+        }
+
+        &.item-two {
+          -moz-animation-delay: 1.85s;
+          -webkit-animation-delay: 1.85s;
+          animation-delay: 1.85s;
+          background-image: url('#{$asset-server}999949f8-picto-startfirst-midaubergine.svg');
+          left: 484px;
+          top: 108px;
+        }
+
+        &.item-two-line,
+        &.item-five-line {
+          -moz-animation-delay: 2s;
+          -webkit-animation-delay: 2s;
+          animation-delay: 2s;
+          background: url('#{$asset-server}4fc1680b-partners-hero-line-diagonal.png');
+          height: 38px;
+          left: 445px;
+          top: 175px;
+          width: 38px;
+        }
+
+        &.item-three {
+          -moz-animation-delay: 2s;
+          -webkit-animation-delay: 2s;
+          animation-delay: 2s;
+          background-image: url('#{$asset-server}60bd6cf1-picto-juju.svg');
+          left: 547px;
+          top: 245px;
+        }
+
+        &.item-three-line,
+        &.item-six-line {
+          -moz-animation-delay: 2.15s;
+          -webkit-animation-delay: 2.15s;
+          animation-delay: 2.15s;
+          background: url('#{$asset-server}d505cff1-partners-hero-line-horizontal.png');
+          height: 2px;
+          left: 469px;
+          top: 277px;
+          width: 52px;
+        }
+
+        &.item-four {
+          -moz-animation-delay: 2.15s;
+          -webkit-animation-delay: 2.15s;
+          animation-delay: 2.15s;
+          background-image: url('#{$asset-server}261ad7cb-picto-maas.svg');
+          left: 367px;
+          top: 425px;
+        }
+
+        &.item-four-line {
+          -moz-animation-delay: 2.3s;
+          -webkit-animation-delay: 2.3s;
+          animation-delay: 2.3s;
+          left: 396px;
+          top: 347px;
+        }
+
+        &.item-five {
+          -moz-animation-delay: 2.3s;
+          -webkit-animation-delay: 2.3s;
+          animation-delay: 2.3s;
+          background-image: url('#{$asset-server}50c0306d-image-picto-landscape.svg');
+          left: 226px;
+          top: 372px;
+        }
+
+        &.item-five-line {
+          -moz-animation-delay: 2.45s;
+          -webkit-animation-delay: 2.45s;
+          animation-delay: 2.45s;
+          left: 301px;
+          top: 328px;
+        }
+
+        &.item-six {
+          -moz-animation-delay: 2.45s;
+          -webkit-animation-delay: 2.45s;
+          animation-delay: 2.45s;
+          background-image: url('#{$asset-server}c986edab-picto-cloud-midaubergine-solid.svg');
+          left: 170px;
+          top: 245px;
+        }
+
+        &.item-six-line {
+          -moz-animation-delay: 2.6s;
+          -webkit-animation-delay: 2.6s;
+          animation-delay: 2.6s;
+          left: 259px;
+          top: 273px;
+        }
+
+        &.item-seven {
+          -moz-animation: scaleIn 0.3s forwards, fadeIn 0.6s linear forwards, rotateIn 3.0s ease-out forwards;
+          -webkit-animation: scaleIn 0.3s forwards, fadeIn 0.6s linear forwards, rotateIn 3.0s ease-out forwards;
+          animation: scaleIn 0.3s forwards, fadeIn 0.6s linear forwards, rotateIn 3.0s ease-out forwards;
+          -moz-animation-delay: 1s;
+          -webkit-animation-delay: 1s;
+          animation-delay: 1s;
+          background: url('#{$asset-server}c4f35e06-partners-hero-ubuntu.svg') no-repeat;
+          left: 320px;
+          top: 198px;
+          height: 140px;
+          width: 140px;
+        }
+      }
+    }
 
     .row-maas {
 

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -22,31 +22,31 @@
             <p class="intro">70% of public cloud workloads and 55% of OpenStack clouds run on Ubuntu.<a href="#fn1" id="r1">*</a></p>
         </div>
         <div class="six-col" style="padding-bottom: 2em;">
-             <ul class="list-ubuntu--compact">
-                 <li>Create your own private cloud with <a class="ab-link-test" href="/cloud/openstack/autopilot">OpenStack Autopilot</a></li>
-                 <li>Get us to build and manage your OpenStack cloud with&nbsp;<a class="ab-link-test" href="/cloud/openstack/managed-cloud">BootStack</a></li>
-                 <li>Deploy applications to any cloud with <a class="ab-link-test" href="/cloud/juju">Juju</a></li>
-                 <li>Get cloud-style automation for physical servers with <a class="ab-link-test" href="/server/maas">MAAS</a></li>
-                 <li>Use Ubuntu on certified <a class="ab-link-test" href="/cloud/public-cloud">public clouds</a></li>
-             </ul>
+            <ul class="list-ubuntu--compact">
+                <li>Create your own private cloud with <a class="ab-link-test" href="/cloud/openstack/autopilot">OpenStack Autopilot</a></li>
+                <li>Get us to build and manage your OpenStack cloud with&nbsp;<a class="ab-link-test" href="/cloud/openstack/managed-cloud">BootStack</a></li>
+                <li>Deploy applications to any cloud with <a class="ab-link-test" href="/cloud/juju">Juju</a></li>
+                <li>Get cloud-style automation for physical servers with <a class="ab-link-test" href="/server/maas">MAAS</a></li>
+                <li>Use Ubuntu on certified <a class="ab-link-test" href="/cloud/public-cloud">public clouds</a></li>
+            </ul>
         </div>
-        <div class="products-hero-container not-for-small">
-        <div class="cloud-tools-list">
-            <a class="item-one" href="/cloud/openstack" title="OpenStack">OpenStack</a>
-            <span class="item-line item-one-line"></span>
-            <a class="item-two" href="/cloud/openstack/managed-cloud" title="BootStack">BootStack</a>
-            <span class="item-line item-two-line"></span>
-            <a class="item-three" href="/cloud/tools/juju" title="Juju">Juju</a>
-            <span class="item-line item-three-line"></span>
-            <a class="item-four" href="/server/maas" title="MAAS">MAAS</a>
-            <span class="item-line item-four-line"></span>
-            <a class="item-five" href="/cloud/openstack/autopilot" title="Autopilot">Autopilot</a>
-            <span class="item-line item-five-line"></span>
-            <a class="item-six" href="/cloud/public-cloud" title="Public cloud">Public cloud</a>
-            <span class="item-line item-six-line"></span>
-            <span class="item-seven">Ubuntu</span>
+        <div class="cloud-tools not-for-small">
+            <div class="cloud-tools__container">
+                <a class="cloud-tools__item cloud-tools__item--one" href="/cloud/openstack" title="OpenStack">OpenStack</a>
+                <span class="cloud-tools__item cloud-tools__item--line cloud-tools__item--line-one"></span>
+                <a class="cloud-tools__item cloud-tools__item--two" href="/cloud/openstack/managed-cloud" title="BootStack">BootStack</a>
+                <span class="cloud-tools__item cloud-tools__item--line cloud-tools__item--line-two"></span>
+                <a class="cloud-tools__item cloud-tools__item--three" href="/cloud/tools/juju" title="Juju">Juju</a>
+                <span class="cloud-tools__item cloud-tools__item--line cloud-tools__item--line-three"></span>
+                <a class="cloud-tools__item cloud-tools__item--four" href="/server/maas" title="MAAS">MAAS</a>
+                <span class="cloud-tools__item cloud-tools__item--line cloud-tools__item--line-four"></span>
+                <a class="cloud-tools__item cloud-tools__item--five" href="/cloud/openstack/autopilot" title="Autopilot">Autopilot</a>
+                <span class="cloud-tools__item cloud-tools__item--line cloud-tools__item--line-five"></span>
+                <a class="cloud-tools__item cloud-tools__item--six" href="/cloud/public-cloud" title="Public cloud">Public cloud</a>
+                <span class="cloud-tools__item cloud-tools__item--line cloud-tools__item--line-six"></span>
+                <span class="cloud-tools__item cloud-tools__item--seven">Ubuntu</span>
+            </div>
         </div>
-</div>
     </div>
 </section>
 

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -17,15 +17,36 @@
 {% block content %}
 <section class="row row-hero no-border strip-light">
     <div class="strip-inner-wrapper">
-        <div class="hero-content twelve-col">
+        <div class="hero-content six-col">
             <h1>Build your cloud strategy with Ubuntu</h1>
             <p class="intro">70% of public cloud workloads and 55% of OpenStack clouds run on Ubuntu.<a href="#fn1" id="r1">*</a></p>
         </div>
-        <div class="twelve-col no-margin-bottom last-col">
-            <div class="video-container">
-                <iframe width="906" height="500" src="https://www.youtube.com/embed/RiEZB1-83wQ?rel=0&amp;&amp;hd=1" frameborder="0" allowfullscreen></iframe>
-            </div>
+        <div class="six-col" style="padding-bottom: 2em;">
+             <ul class="list-ubuntu--compact">
+                 <li>Create your own private cloud with <a class="ab-link-test" href="/cloud/openstack/autopilot">OpenStack Autopilot</a></li>
+                 <li>Get us to build and manage your OpenStack cloud with&nbsp;<a class="ab-link-test" href="/cloud/openstack/managed-cloud">BootStack</a></li>
+                 <li>Deploy applications to any cloud with <a class="ab-link-test" href="/cloud/juju">Juju</a></li>
+                 <li>Get cloud-style automation for physical servers with <a class="ab-link-test" href="/server/maas">MAAS</a></li>
+                 <li>Use Ubuntu on certified <a class="ab-link-test" href="/cloud/public-cloud">public clouds</a></li>
+             </ul>
         </div>
+        <div class="products-hero-container not-for-small">
+        <div class="cloud-tools-list">
+            <a class="item-one" href="/cloud/openstack" title="OpenStack">OpenStack</a>
+            <span class="item-line item-one-line"></span>
+            <a class="item-two" href="/cloud/openstack/managed-cloud" title="BootStack">BootStack</a>
+            <span class="item-line item-two-line"></span>
+            <a class="item-three" href="/cloud/tools/juju" title="Juju">Juju</a>
+            <span class="item-line item-three-line"></span>
+            <a class="item-four" href="/server/maas" title="MAAS">MAAS</a>
+            <span class="item-line item-four-line"></span>
+            <a class="item-five" href="/cloud/openstack/autopilot" title="Autopilot">Autopilot</a>
+            <span class="item-line item-five-line"></span>
+            <a class="item-six" href="/cloud/public-cloud" title="Public cloud">Public cloud</a>
+            <span class="item-line item-six-line"></span>
+            <span class="item-seven">Ubuntu</span>
+        </div>
+</div>
     </div>
 </section>
 
@@ -41,12 +62,11 @@
                 <li>Rapid scaling to add more capacity when you need it</li>
                 <li>Includes management tooling and commercial support from Canonical</li>
             </ul>
-            <p><a href="/download/cloud" class="button--primary">Get OpenStack Autopilot</a></p>
-            <p><a href="/cloud/openstack/autopilot">Learn more about Autopilot&nbsp;&rsaquo;</a></p>
+            <p><a href="/cloud/openstack/autopilot" class="button--primary">Get OpenStack Autopilot</a></p>
         </div>
         <div class="box four-col last-col">
             <h3>Do it yourself?</h3>
-            <p>Manually deploy OpenStack services with Juju.</p>
+            <p>Manually deploy OpenStack services with MAAS and Juju.</p>
             <ul>
                 <li>Bare metal install</li>
                 <li>Guided process</li>
@@ -54,7 +74,7 @@
                 <li>Unmanaged</li>
                 <li>Manual upgrades</li>
             </ul>
-            <p><a href="https://help.ubuntu.com/lts/clouddocs/installer/" class="external">Find out how</a></p>
+            <p><a href="https://help.ubuntu.com/" class="external">Find out how</a></p>
         </div>
     </div>
 </section>
@@ -68,17 +88,15 @@
 <section class="row strip-dark no-border">
     <div class="strip-inner-wrapper">
         <div class="eight-col">
-            <h2>Canonical BootStack is a fully managed private cloud on OpenStack</h2>
+            <h2>BootStack is a fully managed private cloud on OpenStack</h2>
         </div>
         <div class="six-col">
             <ul class="list-ticks--compact">
-                <li>We&rsquo;ll set up an OpenStack cloud on your premises and operate it according to an agreed SLA</li>
+                <li>We&rsquo;ll build an OpenStack cloud on your premises or hosted environment and operate it according to an agreed SLA</li>
                 <li>We&rsquo;ll train your staff to run it</li>
                 <li>When you&rsquo;re ready, we&rsquo;ll hand over the keys</li>
-                <li>&dollar;15 per day per server</li>
-                <li>&dollar;0.05 per hour per fully managed VM</li>
             </ul>
-            <p><a href="/cloud/openstack/managed-cloud#calculator-form" class="button--primary">Calculate your savings</a></p>
+            <p><a href="/cloud/openstack/managed-cloud" class="button--primary">Let us build, operate and transfer your cloud</a></p>
         </div>
         <div class="six-col last-col text-center">
             <img src="{{ ASSET_SERVER_URL }}466046c7-illustration-cloud-bootstack.svg?w=320" alt="" class="not-for-small" width="320" />


### PR DESCRIPTION
## Done

* updated /cloud overview based on Tom's updates, not including moving managed-cloud up
* removed the video, put back the animation
* updated some minor text
* removed old link to the BootStack calculated

## QA

1. go to the /cloud overview
2. compare the text to the [copy doc](https://docs.google.com/document/d/1mQjVXDcoP8ChOzRdmuI55BdXhbURD53qBNc2bgJhfhg/edit#)
3. see that the animation looks ok S/M/L screens... note - the original had a -100 z-index on the main image, I had to remove that

## Issue / Card

[trello card](https://trello.com/c/fybb5zft)
