### PR TITLE
Mobile overview - add border to the bottom of the hero row

### DIFF
--- a/static/css/section/_mobile.scss
+++ b/static/css/section/_mobile.scss
@@ -1,5 +1,11 @@
 .mobile-home {
 
+  .row-hero {
+    @media only screen and (min-width : $breakpoint-medium) {
+      border-bottom: 0;
+    }
+  }
+
   .row--devices {
     overflow: hidden;
 

--- a/templates/mobile/index.html
+++ b/templates/mobile/index.html
@@ -18,7 +18,7 @@ Ubuntu phone, Ubuntu tablet, convergence, mobile, IoT, devices, Linux phone, Lin
 
 {% block content %}
 
-<section class="row row-hero no-border row--devices">
+<section class="row row-hero row--devices">
     <div class="strip-inner-wrapper">
         <div class="six-col">
             <h1>Everything you need from a PC &mdash; in a tablet or phone</h1>


### PR DESCRIPTION
## Done
- Added a border to small screen hero section in mobile section

## QA
- Pull down this branch and run `make run`
- Go to http://127.0.0.1:8001/mobile
- Check that there is no border at the bottom of the hero section
- Scale the window down and see that the border appears