### PR TITLE
Add trans bg to hero text on /desktop/education

### DIFF
--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -448,6 +448,11 @@
   // @subsection /desktop/education
   &.desktop-education {
 
+    .trans-bg {
+      background: rgba(255,255,255,0.85);
+      padding: 0 1rem 1rem;
+    }
+
     .row-hero {
       @media only screen and (min-width: $breakpoint-medium) {
         background-image: url('#{$asset-server}3a51704e-desktop-education-hero.jpg?w=984');

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -14,12 +14,14 @@
 
 <section class="row row-hero strip-light">
    <div class="strip-inner-wrapper">
-        <h1>Ubuntu for education</h1>
-        <div class="five-col">
-            <p class="intro">With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators.</p>
-            <p><a href="/desktop/contact-us" class="button--primary">Contact us</a></p>
-            {% include "desktop/shared/_share-this.html" with tweet="Learn how #Ubuntu desktop OS helps students and teachers around the world" %}
-        </div>
+       <div class="six-col">
+         <div class="trans-bg">
+             <h1>Ubuntu for education</h1>
+             <p class="intro">With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators.</p>
+             <p><a href="/desktop/contact-us" class="button--primary">Contact us</a></p>
+           {% include "desktop/shared/_share-this.html" with tweet="Learn how #Ubuntu desktop OS helps students and teachers around the world" %}
+         </div>
+       </div>
     </div>
 </section>
 


### PR DESCRIPTION
## Done

Add contrast to hero text on /desktop/education

## QA

- Pull code
- Run site
- Go to  /desktop/education
- Check that hero text is now placed in semi-transparent white box

## Issue / Card

Fixes https://github.com/ubuntudesign/www.ubuntu.com/issues/1190