### PR TITLE
Update partner link to include referral

### DIFF
--- a/templates/cloud/shared/_guest-list.html
+++ b/templates/cloud/shared/_guest-list.html
@@ -1,6 +1,6 @@
 <ul class="no-bullets twelve-col equal-height">
     <li class="box four-col equal-height--item">
-        <a href="https://cloud.google.com/docs/">
+        <a href="https://cloud.google.com/partners/partnercredit/?PCN=a0n60000003kyX1&utm_medium=partners&utm_campaign=partner-credit">
             <div>
                 <img class="logo-gcp" src="{{ ASSET_SERVER_URL }}bd47d87c-google-cloud.svg" alt="Google Cloud Platform logo" />
             </div>


### PR DESCRIPTION
## Done

Updated Google Cloud 'Getting Started' link to include referral.

## QA

- Pull code
- Navigate to /cloud/public-cloud
- Scroll to 'Ready to get started?'
- Check that Google Cloud link takes you to: https://cloud.google.com/partners/partnercredit/?PCN=a0n60000003kyX1&utm_medium=partners&utm_campaign=partner-credit

## Issue / Card

gDoc: https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit
