### PR TITLE
cloud/training hero fix for medium screens

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -811,7 +811,7 @@
           max-width: 300px;
           position: absolute;
           right: 20px;
-          top: 0;
+          top: -40px;
         }
 
         @media only screen and (min-width: $breakpoint-large) {


### PR DESCRIPTION
## Done

Fixed the hero of /cloud/training page at medium viewports

## QA

View /cloud/training at medium viewport and behold the hero image is now flush with the top of the row (like in large viewport).

Fixes #1213 