### PR TITLE
Switch out Australian mirror link on alternative download page

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -82,7 +82,7 @@
         </div>
         <h3 class="external--title"><span>Select the nearest mirror</span></h3>
         <ul class="twelve-col no-bullets list">
-            <li class="four-col"><a class="download-mirror" href="http://mirror.eftel.com/ubuntu/releases-DVD/">Australia &rsaquo;</a></li>
+            <li class="four-col"><a class="download-mirror" href="http://mirror.waia.asn.au/ubuntu-releases/">Australia &rsaquo;</a></li>
             <li class="four-col"><a class="download-mirror" href="http://ftp.funet.fi/pub/Linux/INSTALL/Ubuntu/dvd-releases/releases">Finland &rsaquo;</a></li>
             <li class="four-col last-col"><a class="download-mirror" href="ftp://ftp.free.fr/mirrors/ftp.ubuntu.com/releases/">France &rsaquo;</a></li>
             <li class="four-col"><a class="download-mirror" href="http://de.releases.ubuntu.com/">Germany &rsaquo;</a></li>


### PR DESCRIPTION
## Done

Fix 404 link on `/download/alternative-downloads` to 'Australia' mirror

## QA

- Go to /download/alternative-downloads
- Scroll down and click 'Australia'
- Check that link goes to http://mirror.waia.asn.au/ubuntu-releases/

## Issue / Card

Fixes: #1221
