### PR TITLE
Add cloud webinar section

### DIFF
--- a/templates/cloud/openstack/managed-cloud.html
+++ b/templates/cloud/openstack/managed-cloud.html
@@ -34,11 +34,11 @@
 
 <section class="row">
     <div class="strip-inner-wrapper">
-        <h2>Webinars and case studies</h2>
+        <h2>Learn about BootStack managed hosted cloud</h2>
         <ul class="no-bullets equal-height--vertical-divider">
             <li class="four-col equal-height--vertical-divider__item">
                 <img src="https://assets.ubuntu.com/v1/e5f15d33-webinar-1.png?w=300" alt="">
-                <h3>Big Data and Bootstack!</h3>
+                <h3>Big data and BootStack</h3>
                 <p><a class="external" href="https://www.brighttalk.com/webcast/6793/175487">Watch the webinar<span hidden=""> Building success with a Raspberry Pi!</span></a></p>
             </li>
             <li class="four-col equal-height--vertical-divider__item">

--- a/templates/cloud/openstack/managed-cloud.html
+++ b/templates/cloud/openstack/managed-cloud.html
@@ -31,7 +31,32 @@
 </section>
 
 <!-- Section 1 -->
-<section class="row row-hero no-border strip-light">
+
+<section class="row">
+    <div class="strip-inner-wrapper">
+        <h2>Webinars and case studies</h2>
+        <ul class="no-bullets equal-height--vertical-divider">
+            <li class="four-col equal-height--vertical-divider__item">
+                <img src="https://assets.ubuntu.com/v1/e5f15d33-webinar-1.png?w=300" alt="">
+                <h3>Big Data and Bootstack!</h3>
+                <p><a class="external" href="https://www.brighttalk.com/webcast/6793/175487">Watch the webinar<span hidden=""> Building success with a Raspberry Pi!</span></a></p>
+            </li>
+            <li class="four-col equal-height--vertical-divider__item">
+                <img src="https://assets.ubuntu.com/v1/d4b4ad6f-webinar-2.png?w=300" alt="">
+                <h3>Run Windows workloads on BootStack</h3>
+                <p><a class="external" href="https://pages.ubuntu.com/Cloudbase-webinar.html">Watch the webinar<span hidden=""> Data-triggered content and 4G base stations</span></a></p>
+            </li>
+            <li class="four-col last-col equal-height--vertical-divider__item no-margin-bottom">
+                <img src="https://assets.ubuntu.com/v1/04e03cfe-wwebinar-3.png?w=300" alt="">
+                <h3>Build a hyperconverged cloud with BootStack and Supermicro</h3>
+                <p><a class="external" href="https://pages.ubuntu.com/Supermicro_webinar.html">Watch the webinar<span hidden=""> Open Source Digital Signage with Ubuntu</span></a></p>
+            </li>
+        </ul>
+    </div>
+</section>
+
+
+<!-- <section class="row row-hero no-border strip-light">
     <div class="strip-inner-wrapper">
         <div class="twelve-col">
             <h1>Learn about BootStack hosted cloud</h1>
@@ -41,7 +66,7 @@
         </div>
 
     </div>
-</section>
+</section> -->
 
 <!-- Section 2 -->
 
@@ -238,4 +263,3 @@
 forms.addSliders('.add-slider');
 </script>
 {% endblock footer_extra %}
-

--- a/templates/cloud/openstack/managed-cloud.html
+++ b/templates/cloud/openstack/managed-cloud.html
@@ -55,21 +55,7 @@
     </div>
 </section>
 
-
-<!-- <section class="row row-hero no-border strip-light">
-    <div class="strip-inner-wrapper">
-        <div class="twelve-col">
-            <h1>Learn about BootStack hosted cloud</h1>
-            <div class="video-container">
-                <iframe width="906" height="500" src="https://www.youtube.com/embed/hCSTwyG7bbg?rel=0&amp;&amp;hd=1" frameborder="0" allowfullscreen></iframe>
-            </div>
-        </div>
-
-    </div>
-</section> -->
-
 <!-- Section 2 -->
-
 
 <div class="row row-grey row-expertise">
     <div class="strip-inner-wrapper">
@@ -234,22 +220,6 @@
             <h3>BootStack for Kubernetes</h3>
             <p>Whether you want to orchestrate your container cluster on top of your OpenStack cloud or other substrate, we’ll build and operate it for you using the Canonical Distribution of Kubernetes. Focus on your applications not infrastructure.</p>
             <p><a href="/cloud/kubernetes">Learn more about the Canonical Distribution of Kubernetes&nbsp;›</a></p>
-        </div>
-    </div>
-</section>
-
-<!-- Section 6 -->
-<section class="row no-border strip-light">
-    <div class="strip-inner-wrapper">
-        <h2 class="nine-col">BootStack and PLUMgrid SDN</h2>
-
-        <div class="six-col">
-            <img src="{{ ASSET_SERVER_URL }}866eecdb-BootStack+and+PLUMgrid+SDN_screenshot.jpg" alt="" />
-        </div>
-
-        <div class="six-col last-col">
-            <p>See how PLUMgrid leverages BootStack to help enterprises and service providers operationalise their webscale OpenStack and container cloud’s SDN deployments.</p>
-            <p><a class="external" href="https://pages.ubuntu.com/Secure-scale-and-simplify-your-cloud-deployments_webinar.html">Watch the webinar</a></p>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done

- Removed video section
- Added webinar section
- Removed PLUMGRID section as per gDoc

## QA

- Run code
- Navigate to /cloud/openstack/managed-cloud
- Cross ref content with gDoc

## Issue / Card

Trello: https://trello.com/c/vQ8lHilD/2334-managed-cloud-build-webinar-row
gDoc: https://docs.google.com/document/d/1g38PPPhEP0Z66eM_gezfUyUwAr5e9vGfTHJDWV8gZlE/edit#heading=h.830669uz173g