### PR TITLE
removed superfluous border

### DIFF
--- a/templates/cloud/openstack/managed-cloud.html
+++ b/templates/cloud/openstack/managed-cloud.html
@@ -199,7 +199,7 @@
 </section>
 
 <!-- Section 5 -->
-<section class="row">
+<section class="row no-border">
     <div class="strip-inner-wrapper equal-height--vertical-divider">
         <div class="twelve-col">
             <h2>BootStack can be customised to your requirements</h2>


### PR DESCRIPTION
## Done
I noticed that managed cloud had an extra bottom border on the last row, I removed it.

## QA

Check that the border is no longer on the last row of `/cloud/openstack/managed-cloud`