### PR TITLE
update webinars on managed-cloud

### DIFF
--- a/templates/cloud/openstack/managed-cloud.html
+++ b/templates/cloud/openstack/managed-cloud.html
@@ -34,22 +34,22 @@
 
 <section class="row">
     <div class="strip-inner-wrapper">
-        <h2>Learn about BootStack managed hosted cloud</h2>
+        <h2>Learn about BootStack managed cloud</h2>
         <ul class="no-bullets equal-height--vertical-divider">
             <li class="four-col equal-height--vertical-divider__item">
-                <img src="https://assets.ubuntu.com/v1/e5f15d33-webinar-1.png?w=300" alt="">
+                <img src="{{ ASSET_SERVER_URL }}e5f15d33-webinar-1.png?w=300" alt="">
                 <h3>Big data and BootStack</h3>
-                <p><a class="external" href="https://www.brighttalk.com/webcast/6793/175487">Watch the webinar<span hidden=""> Building success with a Raspberry Pi!</span></a></p>
+                <p><a class="external" href="https://www.brighttalk.com/webcast/6793/175487">Watch the webinar<span hidden=""> Big data and BootStack</span></a></p>
             </li>
             <li class="four-col equal-height--vertical-divider__item">
-                <img src="https://assets.ubuntu.com/v1/d4b4ad6f-webinar-2.png?w=300" alt="">
+                <img src="{{ ASSET_SERVER_URL }}5b16e994-webinar-2.png?w=300" alt="">
                 <h3>Run Windows workloads on BootStack</h3>
-                <p><a class="external" href="https://pages.ubuntu.com/Cloudbase-webinar.html">Watch the webinar<span hidden=""> Data-triggered content and 4G base stations</span></a></p>
+                <p><a class="external" href="https://pages.ubuntu.com/Cloudbase-webinar.html">Watch the webinar<span hidden=""> un Windows workloads on BootStack</span></a></p>
             </li>
             <li class="four-col last-col equal-height--vertical-divider__item no-margin-bottom">
-                <img src="https://assets.ubuntu.com/v1/04e03cfe-wwebinar-3.png?w=300" alt="">
+                <img src="{{ ASSET_SERVER_URL }}04e03cfe-wwebinar-3.png?w=300" alt="">
                 <h3>Build a hyperconverged cloud with BootStack and Supermicro</h3>
-                <p><a class="external" href="https://pages.ubuntu.com/Supermicro_webinar.html">Watch the webinar<span hidden=""> Open Source Digital Signage with Ubuntu</span></a></p>
+                <p><a class="external" href="https://pages.ubuntu.com/Supermicro_webinar.html">Watch the webinar<span hidden=""> Build a hyperconverged cloud with BootStack and Supermicro</span></a></p>
             </li>
         </ul>
     </div>
@@ -66,7 +66,7 @@
 
             <div class="four-col equal-height--vertical-divider__item clearfix">
                 <div class="inline-small align-center">
-                    <img class="grid-list__img" src="https://assets.ubuntu.com/v1/14cf6193-pictogram-reduce_costs-orange-hex.svg" alt="">
+                    <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}14cf6193-pictogram-reduce_costs-orange-hex.svg" alt="">
                 </div>
                 <div class="no-margin-bottom">
                     <h3>Predictable costs</h3>
@@ -76,7 +76,7 @@
 
             <div class="four-col equal-height--vertical-divider__item clearfix">
                 <div class="inline-small align-center">
-                    <img class="grid-list__img" src="https://assets.ubuntu.com/v1/31c507a5-image-juju.svg" alt="">
+                    <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}31c507a5-image-juju.svg" alt="">
                 </div>
                 <div class="no-margin-bottom">
                     <h3>Model your workloads with Juju</h3>
@@ -86,7 +86,7 @@
 
             <div class="four-col equal-height--vertical-divider__item clearfix last-col">
                 <div class="inline-small align-center">
-                    <img class="grid-list__img" src="https://assets.ubuntu.com/v1/878af602-pictogram-virtualisation-orange-hex.svg" alt="">
+                    <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}878af602-pictogram-virtualisation-orange-hex.svg" alt="">
                 </div>
                 <div class="no-margin-bottom">
                     <h3>Easy network function virtualisation</h3>
@@ -99,7 +99,7 @@
 
             <div class="four-col equal-height--vertical-divider__item clearfix">
                 <div class="inline-small align-center">
-                    <img class="grid-list__img" src="https://assets.ubuntu.com/v1/b35c8ec0-storage.svg" alt="">
+                    <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}b35c8ec0-storage.svg" alt="">
                 </div>
                 <div class="no-margin-bottom">
                     <h3>Cloud native storage</h3>
@@ -109,7 +109,7 @@
 
             <div class="four-col equal-height--vertical-divider__item clearfix">
                 <div class="inline-small align-center">
-                    <img class="grid-list__img" src="https://assets.ubuntu.com/v1/dbfe22f3-pictogram-certification-orange-hex.svg" alt="">
+                    <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}dbfe22f3-pictogram-certification-orange-hex.svg" alt="">
                 </div>
                 <div class="no-margin-bottom">
                     <h3>Guaranteed availability and quality</h3>
@@ -119,7 +119,7 @@
 
             <div class="four-col equal-height--vertical-divider__item clearfix last-col">
                 <div class="inline-small align-center">
-                    <img class="grid-list__img" src="https://assets.ubuntu.com/v1/921119ff-pictogram-training-orange-hex.svg" alt="">
+                    <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}921119ff-pictogram-training-orange-hex.svg" alt="">
                 </div>
                 <div class="no-margin-bottom">
                     <h3>Complete control and no vendor lock-in</h3>


### PR DESCRIPTION
## Done

* on /cloud/openstack/managed-cloud
  * fixed the webinar section heading
  * updated the image
  * updated the hidden span copy
  * used the {{ ASSET_SERVER_URL }} variable


## QA

* go to cloud/openstack/managed-cloud
* see the heading is updated per the [copy doc](https://docs.google.com/document/d/1g38PPPhEP0Z66eM_gezfUyUwAr5e9vGfTHJDWV8gZlE/edit#)
* see the second [image](https://assets.ubuntu.com/v1/5b16e994-webinar-2.png) has been updated
* see the hidden text is relevant (not digital signage)

## Issue / Card

[trello card](https://trello.com/c/AF1FzJRU)