### PR TITLE
minor copy updates and styling tweaks

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -435,6 +435,10 @@
         }
       }
     }
+
+    .row--office-hours {
+      background-image: none;
+    }
   }
 
   //  @subsection cloud/storage - XXX this is a candidate to raise up a level */

--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -181,6 +181,10 @@
     .row-hero {
       @media only screen and (min-width : $animation-viewport) {
         min-height: 550px;
+
+        .six-col {
+          z-index: 2;
+        }
       }
 
       .strip-inner-wrapper {
@@ -196,6 +200,7 @@
           position: absolute;
           top: -30px;
           width: 100%;
+          z-index: 1;
 
           &__container {
             background: url('#{$asset-server}79729d72-products-hero-background.png') no-repeat;

--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -29,6 +29,7 @@
                 <li>Get cloud-style automation for physical servers with <a class="ab-link-test" href="/server/maas">MAAS</a></li>
                 <li>Use Ubuntu on certified <a class="ab-link-test" href="/cloud/public-cloud">public clouds</a></li>
             </ul>
+            <p><a href="http://ubunt.eu/OpenStack_officehour" class="external">Sign up for OpenStack and containers office hours</a></p>
         </div>
         <div class="cloud-tools not-for-small">
             <div class="cloud-tools__container">
@@ -238,7 +239,7 @@
     </div>
 </section>
 
-<section class="row">
+<section class="row no-border">
     <div class="strip-inner-wrapper">
         <div class="eight-col">
             <h2>Use Ubuntu on certified public clouds</h2>
@@ -252,6 +253,20 @@
         </div>
         <div class="four-col last-col">
             <figure id="ubuntu-pie" class="ubuntu-pie align-center"></figure>
+        </div>
+    </div>
+</section>
+
+<section class="row strip-dark row--office-hours no-border">
+    <div class="strip-inner-wrapper equal-height">
+        <div class="six-col equal-height__item">
+            <h2>OpenStack and containers office&nbsp;hours</h2>
+            <p>Sign-up for a one-hour web session with an expert from Canonical.</p>
+            <p>Get help with Ubuntu OpenStack, Autopilot, Kubernetes, LXD, Juju and MAAS. Ask as many questions as you want.</p>
+            <p><a href="http://ubunt.eu/OpenStack_officehour" class="button--primary">Register now</a></p>
+        </div>
+        <div class="six-col last-col equal-height__item align-center">
+            <img src="{{ ASSET_SERVER_URL }}b0e012b6-Openstack+Surgery+-+Dark+background.svg" alt="" />
         </div>
     </div>
 </section>


### PR DESCRIPTION
This has already been reviewed by @pmahnke but is now being re-merged

The previous review was: #1226

## Done

Added a new row for "office hours" on `/cloud` with a few other related changes.

## QA

Compare `/cloud` to the [copydoc](https://docs.google.com/document/d/1mQjVXDcoP8ChOzRdmuI55BdXhbURD53qBNc2bgJhfhg/edit#) and check in-browser.
