### PR TITLE
Remove the abbr for the lts global variable

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -3,7 +3,7 @@
 
 {# Release versions - update as appropriate #}
 {% with latest_release_name="YakketyYak" latest_release="16.10" latest_release_full='16.10' %}
-{% with lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.1" lts_release_full='16.04 <abbr title="long-term support">LTS</abbr>' lts_release_with_point="16.04.1" lts_release_full_with_point='16.04.1 <abbr title="long-term support">LTS</abbr>' %}
+{% with lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.1" lts_release_full='16.04 LTS' lts_release_with_point="16.04.1" lts_release_full_with_point='16.04.1 <abbr title="long-term support">LTS</abbr>' %}
 {% with openstack_version="Mitaka" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done
Remove the abbr from the global lts_full variable as it is used as content in the GA tag on buttons. 

## QA 
- Go to/download/server 
- Check the download LTS button contains just `download`
- Check on live that the GA event is partly visible in the button text

