### PR TITLE
reorder footer columns to match nav and equal widths

### DIFF
--- a/static/css/_global-settings.scss
+++ b/static/css/_global-settings.scss
@@ -1,4 +1,4 @@
-$asset-server: "https://assets.ubuntu.com/v1/";
+$asset-server: 'https://assets.ubuntu.com/v1/';
 $navigation-threshold: 1024px;
 $viewport-threshold: 1281px;
-/* usage: background: url(#{$asset-server}/backgrounds/background.jpg) no-repeat 0 0; */
+$footer-border: #d7d7d7;

--- a/static/css/section/_footer.scss
+++ b/static/css/section/_footer.scss
@@ -25,10 +25,12 @@ footer.global {
   }
 
   /// thick borders
-  .footer-c, .footer-b, #nav-global {
-    -moz-box-shadow: 0 -4px 4px -4px rgba(0,0,0,0.3) inset;
-    -webkit-box-shadow: 0 -4px 4px -4px rgba(0,0,0,0.3) inset;
-    box-shadow: 0 -4px 4px -4px rgba(0,0,0,0.3) inset;
+  .footer-c,
+  .footer-b,
+  #nav-global {
+    -moz-box-shadow: 0 -4px 4px -4px rgba(0,0,0,.3) inset;
+    -webkit-box-shadow: 0 -4px 4px -4px rgba(0,0,0,.3) inset;
+    box-shadow: 0 -4px 4px -4px rgba(0,0,0,.3) inset;
   }
 
   .footer-a, .footer-b {
@@ -38,7 +40,7 @@ footer.global {
         margin: 0;
         padding: 0;
         line-height: 2.11111111em;
-        border-top: 1px solid #ccc;
+        border-top: 1px solid $footer-border;
       }
     }
   }
@@ -66,7 +68,7 @@ footer.global {
 
       a:link,
       a:visited {
-        color: #888;
+        color: $warm-grey;
       }
 
       a::after {
@@ -250,7 +252,7 @@ footer.global {
       background-repeat: no-repeat;
       background-size: 14px 14px;
       border-bottom: 0 none;
-      color: #888888;
+      color: $warm-grey;
       display: block;
       float: none;
       font-weight: 400;
@@ -342,7 +344,7 @@ footer.global {
     -moz-box-shadow: none;
     -webkit-box-shadow: none;
     box-shadow: none;
-    background: #efefef;
+    background: $box-solid-grey;
     width: 100%;
     height: 30px;
     line-height: 19.2px;
@@ -352,7 +354,7 @@ footer.global {
 
     .nav-global-wrapper {
       width: auto;
-      background: none repeat scroll 0 0 #FFFFFF;
+      background: none repeat scroll 0 0 $white;
       margin: 0 auto;
       position: relative;
       text-align: left;
@@ -383,16 +385,16 @@ footer.global {
       }
 
       ul {
-       display: none;
-       float: none;
-       background: #fff;
-       position: absolute;
-       min-width: 120px;
-       top: 30px;
-       border-top: 1px solid #d7d7d7;
-       -webkit-box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
-       -moz-box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
-       box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
+        background: $white;
+        border-top: 1px solid $footer-border;
+        -webkit-box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
+        -moz-box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
+        box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
+         display: none;
+         float: none;
+         position: absolute;
+         min-width: 120px;
+         top: 30px;
 
        li:first-of-type {
          padding-top: 5px;
@@ -438,8 +440,8 @@ footer.global {
     }
 
     a.active {
-      color: #dd4814;
-      border-top: 3px solid #dd4814;
+      color: $ubuntu-orange;
+      border-top: 3px solid $ubuntu-orange;
       text-decoration: none;
       opacity: 1;
     }
@@ -467,15 +469,15 @@ footer.global {
   }
 
   .open {
-    background: #fff;
+    background: $white;
     min-width: 120px;
-    border-left: 1px solid #d7d7d7;
-    border-right: 1px solid #d7d7d7;
+    border-left: 1px solid $footer-border;
+    border-right: 1px solid $footer-border;
 
     a:link,
     a:visited,
     span {
-      color: #dd4814;
+      color: $ubuntu-orange;
       opacity: 1;
     }
 
@@ -540,9 +542,13 @@ footer.global {
     .footer-a {
       padding: 20px 0;
       margin-bottom: 20px;
-      border-bottom: 1px solid #d8d8d8;
+      border-bottom: 1px solid $footer-border;
       display: block;
       clear: both;
+
+      .secondary {
+        width: 14.25%;
+      }
 
       .second-level-nav li > a {
         padding: 0;
@@ -563,7 +569,7 @@ footer.global {
           width: 100%;
 
           li {
-            border-right: 1px dotted #888;
+            border-right: 1px dotted $warm-grey;
             display: table-cell;
             float: none;
             margin-left: 0;

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -17,14 +17,14 @@
                     <li class="secondary secondary-desktop"><h2><a href="/desktop" class="active-trail">Desktop</a></h2>
                         {% include "desktop/_nav_secondary.html" %}
                     </li>
+                    <li class="secondary secondary-core"><h2><a id="core-footer" href="/internet-of-things">Core</a></h2>
+                        {% include "core/_nav_secondary.html" %}
+                    </li>
                     <li class="secondary secondary-iot"><h2><a id="IoT-footer" href="/internet-of-things">IoT</a></h2>
                         {% include "internet-of-things/_nav_secondary.html" %}
                     </li>
                     <li class="secondary secondary-mobile"><h2><a id="mobile-footer" href="/mobile">Mobile</a></h2>
                         {% include "mobile/_nav_secondary.html" %}
-                    </li>
-                    <li class="secondary secondary-core"><h2><a id="core-footer" href="/internet-of-things">Core</a></h2>
-                        {% include "core/_nav_secondary.html" %}
                     </li>
                     <li class="secondary secondary-support"><h2><a href="/support">Support</a></h2>
                         {% include "support/_nav_secondary.html" %}


### PR DESCRIPTION
## Done

* reordered the footer columns to match the main nav
* added a width of 14.25% for the columns so they are equal in width
* cleaned up the _footer.scss a little with some color variables and lint errors (not complete)

## QA

1. on ubuntu.com see that the footer is in the same order as the main nav
2. see that the column widths are mostly equal

## Issue / Card

fixes #1202

## Screenshots

old
![image](https://cloud.githubusercontent.com/assets/441217/21718008/5acf2556-d40c-11e6-826b-1abec70a76c5.png)

new
![image](https://cloud.githubusercontent.com/assets/441217/21718013/665456da-d40c-11e6-8cfd-c4ad893b74c9.png)
