### PR TITLE
add analytics event triggers to the external links on cloud overview

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -29,7 +29,7 @@
                 <li>Get cloud-style automation for physical servers with <a class="ab-link-test" href="/server/maas">MAAS</a></li>
                 <li>Use Ubuntu on certified <a class="ab-link-test" href="/cloud/public-cloud">public clouds</a></li>
             </ul>
-            <p><a href="http://ubunt.eu/OpenStack_officehour" class="external">Sign up for OpenStack and containers office hours</a></p>
+            <p><a href="http://ubunt.eu/OpenStack_officehour" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Cloud overview', 'eventLabel' : 'Sign up for OpenStack and containers office hours', 'eventValue' : undefined });">Sign up for OpenStack and containers office hours</a></p>
         </div>
         <div class="cloud-tools not-for-small">
             <div class="cloud-tools__container">
@@ -263,7 +263,7 @@
             <h2>OpenStack and containers office&nbsp;hours</h2>
             <p>Sign-up for a one-hour web session with an expert from Canonical.</p>
             <p>Get help with Ubuntu OpenStack, Autopilot, Kubernetes, LXD, Juju and MAAS. Ask as many questions as you want.</p>
-            <p><a href="http://ubunt.eu/OpenStack_officehour" class="button--primary">Register now</a></p>
+            <p><a href="http://ubunt.eu/OpenStack_officehour" class="button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Cloud overview', 'eventLabel' : 'Register now', 'eventValue' : undefined });">Register now</a></p>
         </div>
         <div class="six-col last-col equal-height__item align-center">
             <img src="{{ ASSET_SERVER_URL }}b0e012b6-Openstack+Surgery+-+Dark+background.svg" alt="" />


### PR DESCRIPTION
## Done

Added new Google analytic events to the new external links on the cloud overview.

## QA

Go to `/cloud` and see the links to office hours now have events.
