### PR TITLE
replace maas screenshot with one with a border on the bottom

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -366,7 +366,7 @@
     .row-maas {
 
       @media only screen and (min-width : $breakpoint-medium) {
-        background-image: url('#{$asset-server}ee944209-screenshot-cloud_maas.png?w=800');
+        background-image: url('#{$asset-server}90669a61-screenshot-cloud_maas.png?w=800');
         background-position: 100% 50%;
         background-repeat: no-repeat;
         background-size: 45%;

--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -121,7 +121,7 @@
     .row-hero {
 
       @media only screen and (min-width: $breakpoint-medium) {
-        background-image: url('#{$asset-server}ee944209-screenshot-cloud_maas.png?w=800');
+        background-image: url('#{$asset-server}90669a61-screenshot-cloud_maas.png?w=800');
         background-position: 100% 33%;
         background-repeat: no-repeat;
         background-size: 50%;


### PR DESCRIPTION
## Done

* replaced the MAAS screenshot on /cloud and /server/maas with one with a border on the bottom

## QA

1. go to [/cloud](http://www.ubuntu.com-1214-add-border-maas-screenshot.demo.haus/cloud) and [/server/maas](http://www.ubuntu.com-1214-add-border-maas-screenshot.demo.haus/server/maas)
2. see the MAAS screenshot has a nice bottom border

## Issue / Card

Fixes #1214 
