### PR TITLE
remove negative bottom margin from gaming section

### DIFF
--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -305,7 +305,6 @@
           color: $white;
           z-index: 3000;
           margin-top: 30%;
-          margin-bottom: -40px;
         }
 
         @media only screen and (min-width : $viewport-threshold) {


### PR DESCRIPTION
## Done

* removed margin-bottom: -40px; so text isn't clipped on medium and larger screens

## QA

1. go to /desktop/features and see that Gaming row's content isn't clipped

## Issue / Card

Fixes #1203 

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/21722778/f08af160-d425-11e6-9e26-78d9b36e2b02.png)
