### PR TITLE
add Paul O’Reilly quote to /cloud/kubernetes

### DIFF
--- a/templates/cloud/kubernetes.html
+++ b/templates/cloud/kubernetes.html
@@ -27,6 +27,17 @@
     </div>
 </section>
 
+<section class="row row-cool-grey">
+    <div class="strip-inner-wrapper">
+        <div class="prepend-three eight-col">
+          <blockquote class="pull-quote">
+            <p style="font-size: 2rem;"><span>“</span>Canonical Kubernetes is fantastic.<span>”</span></p>
+            <p><cite><a href="https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/151#issuecomment-267177736" class="external">Paul O'Reilly on GitHub</a></cite></p>
+          </blockquote>
+        </div>
+      </div>
+</section>
+
 <section class="row strip-light">
     <div class="strip-inner-wrapper">
         <div class="twelve-col">


### PR DESCRIPTION
## Done

* added Paul O'Reilly quote to /cloud/kubernetes page

## QA

1. go to /cloud/kubernetes
2. see the quote after the banner

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/21799926/048d2a10-d724-11e6-9fa8-894016e569b2.png)


## Notes

* @yaili approved this
* [copy doc](https://docs.google.com/document/d/1VMu4i8rJHW7BXKiOiy36XVFsihVxrNEMzUHn3X2XabI/edit#) needs updating