### PR TITLE
Livepatch takeover2

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base_index.html" %}
 
-{% block takeover_body_class %}homepage-advantage{% endblock takeover_body_class %}
+{% block takeover_body_class %}homepage-livepatch{% endblock takeover_body_class %}
 
 {% block head_extra %}
 <script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
@@ -8,7 +8,7 @@
 
 {% block takeover_content %}
 
-{% include "takeovers/_advantage.html" %}
+{% include "takeovers/_livepatch.html" %}
 
 
 {% get_rss_feed "https://insights.ubuntu.com/tag/spotlight/feed" limit=1 as spotlight_feed %}

--- a/templates/takeovers/_livepatch.html
+++ b/templates/takeovers/_livepatch.html
@@ -1,8 +1,8 @@
 <section class="row row-hero no-border-bottom">
     <div class="strip-inner-wrapper">
-        <h1 class="seven-col">Apply critical kernel patches&nbsp;without rebooting</h1>
-        <p class="six-col">The Canonical Livepatch Service for Ubuntu 16.04 LTS reduces downtime while maintaining compliance and security.</p>
+        <h1 class="seven-col">Managed live kernel patching without&nbsp;reboots</h1>
+        <p class="six-col">Canonical Livepatch Service for Ubuntu 16.04 LTS reduces downtime while maintaining compliance and security.</p>
         <img src="{{ ASSET_SERVER_URL }}2193f4aa-livepatch-laptop.png?w=768" alt="laptop with live patch work" class="for-small six-col row-hero__image" />
-        <p class="six-col"><a class="button--primary" href="/server/livepatch" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Livepatch takeover', 'eventLabel' : 'Learn more', 'eventValue' : undefined });">Learn more</a></p>
+        <p class="six-col"><a class="button--primary" href="/server/livepatch" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : 'Livepatch takeover 2017', 'eventLabel' : 'Learn more', 'eventValue' : undefined });">Learn more</a></p>
     </div>
 </section>


### PR DESCRIPTION
## Done

Reactivated the old livepatch takeover and swapped out the copy

## QA

Check the homepage takeover visually and ensure that the [correct copy](https://docs.google.com/document/d/1A4elyjKsRJw6mK58raN3O7ed_xwZoCLdm7Bk9qJA8tE/edit#heading=h.meo0azuz09li) is being used.