### PR TITLE
add product name to thank you pages for easier tracking

### DIFF
--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -13,19 +13,19 @@
 
         {% if product == 'digital-signage' %}
 
-            {% include "shared/_client-contact-us-form.html" with h1="Contact us about digital signage" intro_text="If you are thinking about building a digital signage product on Ubuntu, please fill in your details below and a member of our team will get in touch."  formid="1422" lpId="2166"  returnURL="http://ubuntu.com/internet-of-things/thank-you"  %}
+            {% include "shared/_client-contact-us-form.html" with h1="Contact us about digital signage" intro_text="If you are thinking about building a digital signage product on Ubuntu, please fill in your details below and a member of our team will get in touch."  formid="1422" lpId="2166"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=digital-signage"  %}
 
         {% elif product == 'gateways' %}
 
-            {% include "shared/_client-contact-us-form.html" with h1="Contact us about gateways"  intro_text="If you would like to know more about Ubuntu for edge gateways please fill in your details below and a member of our team will get in touch."  formid="1663" lpId="3143"  returnURL="http://ubuntu.com/internet-of-things/thank-you"  %}
+            {% include "shared/_client-contact-us-form.html" with h1="Contact us about gateways"  intro_text="If you would like to know more about Ubuntu for edge gateways please fill in your details below and a member of our team will get in touch."  formid="1663" lpId="3143"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=gateways"  %}
 
         {% elif product == 'robotics' %}
 
-            {% include "shared/_client-contact-us-form.html" with h1="Contact us about robotics"  intro_text="If you would like to know more about Ubuntu for Robotics please fill in your details below and a member of our team will get in touch."  formid="1650" lpId="2838"  returnURL="http://ubuntu.com/internet-of-things/thank-you"  %}
+            {% include "shared/_client-contact-us-form.html" with h1="Contact us about robotics"  intro_text="If you would like to know more about Ubuntu for Robotics please fill in your details below and a member of our team will get in touch."  formid="1650" lpId="2838"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=robotics"  %}
 
         {% else %}
 
-            {% include "shared/_client-contact-us-form.html" with h1="Contact us" intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch."  formid="1266" lpId="2551"  returnURL="http://ubuntu.com/internet-of-things/thank-you"  %}
+            {% include "shared/_client-contact-us-form.html" with h1="Contact us" intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch."  formid="1266" lpId="2551"  returnURL="http://ubuntu.com/internet-of-things/thank-you?product=iot"  %}
 
         {% endif %}
 


### PR DESCRIPTION
## Done

* added name=value get strings to /internet-of-things thank you pages to make tracking easier
* the name=value isn't used by the thank-you page in any way

## QA

* Use any of the IOT contact us pages and see you are redirected to the thank-you page with a string:

1. Core page: www.ubuntu.com/internet-of-things/thank-you?product=iot
2. Digital signage page: www.ubuntu.com/internet-of-things/thank-you?product=digital-signage
3. Robotics page: www.ubuntu.com/internet-of-things/thank-you?product=robotics
4. Gateway page: www.ubuntu.com/internet-of-things/thank-you?product=gateways

## Issue / Card

Fixes #1244 
