### PR TITLE
Reference current page in issues

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -62,7 +62,7 @@
           var bugLink = document.querySelector('#report-a-bug');
           bugLink.href += '?body=%0a%0a%0a---%0a*Reported%20from:%20' + location.href + '*';
         </script>
-        <span class="accessibility-aid"><a href="#">Got to the top of the page</a></span>
+        <span class="accessibility-aid"><a href="#">Go to the top of the page</a></span>
     </div><!-- /.legal -->
 </footer>
 {% endblock footer %}

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -55,8 +55,13 @@
         <p class="twelve-col">&copy; {% now "Y" %} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
         <ul class="inline-list clear">
             <li><a accesskey="8" href="/legal">Legal information</a></li>
-            <li><a href="https://github.com/ubuntudesign/www.ubuntu.com/issues/new">Report a bug on this site</a></li>
+            <li><a href="https://github.com/ubuntudesign/www.ubuntu.com/issues/new" id="report-a-bug">Report a bug on this site</a></li>
         </ul>
+        <script>
+          /* Add the page to the report a bug link */
+          var bugLink = document.querySelector('#report-a-bug');
+          bugLink.href += '?body=%0a%0a%0a---%0a*Reported%20from:%20' + location.href + '*';
+        </script>
         <span class="accessibility-aid"><a href="#">Got to the top of the page</a></span>
     </div><!-- /.legal -->
 </footer>


### PR DESCRIPTION
Use JavaScript to add the current page to the "Report an issue" link.

*Note*: This clobbers the existing issue template. Personally I think that's a good thing :trollface:.

QA
--

Run the site, go to any page, click "Report an bug on this site" in the footer.

Check the issue description is filled in to mention the page you came from.