### PR TITLE
new support contact row

### DIFF
--- a/static/css/section/_support.scss
+++ b/static/css/section/_support.scss
@@ -10,6 +10,17 @@
 
 //	@section all /support
 .support {
+  .row.row--contact-us {
+    padding-bottom: 20px;
+    padding-top: 20px;
+  }
+
+  .row--contact-us__wrapper {
+    background-image: url('#{$asset-server-url}00d6e773-contact_orange_phone.svg');
+    background-position: 10px;
+    background-repeat: no-repeat;
+    padding-left: 60px;
+  }
 
   // @subsections /support/plans-and-pricing
   &.support-plans-and-pricing {

--- a/templates/shared/_call-sales.html
+++ b/templates/shared/_call-sales.html
@@ -1,0 +1,7 @@
+<section class="row strip-light row--contact-us">
+  <div class="strip-inner-wrapper">
+    <div class="twelve-col last-col no-margin-bottom row--contact-us__wrapper">
+      <p class="intro">Any questions? <a href="/support/contact-us">Contact our team</a> or call direct: Americas: <tel href="tel:+1 781 761 9427">+1&nbsp;781&nbsp;761&nbsp;9427</tel>, <abbr title="Rest of the world">RoW</abbr>: <tel href="tel:+44 207 093 5161">+44&nbsp;207&nbsp;093&nbsp;5161</tel></p>
+    </div>
+  </div>
+</section>

--- a/templates/shared/_call-sales.html
+++ b/templates/shared/_call-sales.html
@@ -1,7 +1,11 @@
 <section class="row strip-light row--contact-us">
   <div class="strip-inner-wrapper">
     <div class="twelve-col last-col no-margin-bottom row--contact-us__wrapper">
-      <p class="intro">Any questions? <a href="/support/contact-us">Contact our team</a> or call direct: Americas: <tel href="tel:+1 781 761 9427">+1&nbsp;781&nbsp;761&nbsp;9427</tel>, <abbr title="Rest of the world">RoW</abbr>: <tel href="tel:+44 207 093 5161">+44&nbsp;207&nbsp;093&nbsp;5161</tel></p>
+        <p class="intro">Any questions? Call us on
+            <tel href="tel:+1 781 761 9427">+1&nbsp;781&nbsp;761&nbsp;9427</tel> (Americas),
+            <tel href="tel:+44 207 093 5161">+44&nbsp;207&nbsp;093&nbsp;5161</tel> (<abbr title="Rest of the world">RoW</abbr>) or
+            <a href="/support/contact-us">contact us online</a>.
+        </p>
     </div>
   </div>
 </section>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -22,13 +22,14 @@
             <h1 class="u-full-width">Ubuntu Advantage commercial support</h1>
             <p>Ubuntu Advantage is the commercial support package from Canonical. It includes Landscape, the Ubuntu systems management tool, and the Canonical Livepatch Service, which enables you to apply kernel fixes without restarting your Ubuntu {{lts_release_full}} systems.</p>
             <p><a href="https://buy.ubuntu.com" class="button--primary"><span class="external">Visit the Ubuntu Advantage store</span></a></p>
-            <p><a href="/support/contact-us">Contact us about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
         </div>
         <div class="five-col last-col equal-height__item equal-height__align-vertically">
             <img class="u-full-width priority-0" alt="" width="288" height="155" src="{{ ASSET_SERVER_URL }}11da76f5-image-management.svg" />
         </div>
     </div>
 </section>
+
+{% include "shared/_call-sales.html" %}
 
 <section class="row row-white">
     <div class="strip-inner-wrapper">


### PR DESCRIPTION
## Done

Added a new row under the hero on `/support`

## QA

 - Go to `/support` and see the new row in all its splendour.
 - Check in all viewports and against the [copydoc](https://docs.google.com/document/d/1liY2ulrI3JiICSJquTn9cH0Hu-R6H3ufmEmYhive-QI/edit#)