### PR TITLE
Stop missing CSS from causing 500 error

### DIFF
--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -2,7 +2,7 @@ Django==1.9.6
 whitenoise==3.1
 django-yaml-redirects==0.5.3
 django-asset-server-url==0.1
-django-versioned-static-url==0.1.1
+django-versioned-static-url==0.8
 django-template-finder-view==0.2
 django-static-root-finder==0.3.1
 django-unslashed==0.3.0


### PR DESCRIPTION
This is the fault of django-versioned-static-url, and is fixed simply by upgrading it.

QA
---

Remove built CSS:

``` bash
rm -rf static/css/styles.css
```

Now run the site without building sass:

```  bash
virtualenv env
env/bin/pip install -r requirements/dev.txt
env/bin/python manage.py runserver 0.0.0.0:8001
```

Now visit <http://127.0.0.1:8001>. It should look unstyled, but it *should not* give you a 500 error.

<http://127.0.0.1:8001/static/css/styles.css> should give you a 404.