### PR TITLE
Add link checking to automated (travis) tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,24 @@
 language: python
 python:
   - "2.7"
+
+before_install:
+  - nvm install 7.4.0
+  - nvm use 7.4.0
+
 install:
-  - pip install flake8==3.0.4
+  - npm install --legacy-bundling
+  - npm install node-sass
+  - node_modules/node-sass/bin/node-sass --include-path node_modules static/css --output static/css
+  - pip install --upgrade pip
+  - pip install -r requirements.txt
+  - pip install flake8 requests[security]
+  - pip install https://github.com/nottrobin/linkchecker/archive/fix-install.zip
+
+before_script:
+  - python manage.py runserver &
+
 script:
-  - flake8
+  - flake8 webapp
+  - sleep 2 && linkchecker --threads 2 --ignore-url /usn --no-warnings http://127.0.0.1:8000
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ feedparser==5.2.1
 lockfile==0.12.2
 requests==2.10.0
 requests-cache==0.4.12
-ubuntudesign.gsa==1.0.2
+ubuntudesign.gsa==1.0.3

--- a/templates/legal/_nav_tertiary.html
+++ b/templates/legal/_nav_tertiary.html
@@ -39,6 +39,6 @@
     {% endif %}
 
     {% if level_2 == 'short-terms' and level_3 == '2016-05-20' %}
-    <li><a{% if level_3 == '2016-05-20' %} class="active"{% endif %} href="/legal/short-terms/2015-05-20">2016-05-20</a></li>
+    <li><a{% if level_3 == '2016-05-20' %} class="active"{% endif %} href="/legal/short-terms/2016-05-20">2016-05-20</a></li>
     {% endif %}
 </ul>

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -47,6 +47,7 @@ REMOVE_SLASH = True
 
 # SEARCH_SERVER_URL = 'http://butlerov.internal/search'
 SEARCH_SERVER_URL = 'http://10.22.112.8/search'
+SEARCH_TIMEOUT = 10
 
 MIDDLEWARE_CLASSES = [
     'unslashed.middleware.RemoveSlashMiddleware',


### PR DESCRIPTION
This will run linkchecker across a local run of the whole site, and will error if it finds any 404s or 500s.

There are a couple of downsides to doing this:

- This will probably mean builds take an extra minute
- Builds could break without any code having changed - if a URL we're linking to goes down.
  This will unfortunately mean someone may be tasked with updating a 404 link that was not their fault to get their PR to pass.

I think on balance the value we get from automatically checking for 404s and 500s is worth these downsides. The reviewer can decide if they agree with me.

QA
---

Check the travis build passes.