### PR TITLE
Design updates

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -97,11 +97,14 @@ html.opera-mini {
     margin-bottom: 0;
 }
 
-.download-cloud-home .row--ebook,
-.download-server-provisioning .row--ebook,
-.download-cloud-conjure-up .row--ebook {
-  background: $dark-aubergine;
-  color: #ebebea;
+.download-cloud-home,
+.download-server-provisioning,
+.download-cloud-conjure-up,
+.download-cloud-autopilot  {
+  .row--ebook {
+    background: $dark-aubergine;
+    color: #ebebea;
+  }
 }
 
 .download-desktop {

--- a/templates/download/cloud/autopilot.html
+++ b/templates/download/cloud/autopilot.html
@@ -6,6 +6,8 @@
 
 {% block meta_keywords %}OpenStack, Cloud, Ubuntu OpenStack, private cloud, public cloud, open-source,  IAAS, infrastructure, service, Ubuntu, Ubuntu Cloud Infrastructure, Ubuntu Cloud Guest, Juju, Maas, orchestration, deployment, provisioning{% endblock %}
 
+{% block extra_body_class %}download-cloud-autopilot{% endblock %}
+
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
   {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Cloud" page_title="Autopilot"  %}

--- a/templates/download/cloud/conjure-up.html
+++ b/templates/download/cloud/conjure-up.html
@@ -50,7 +50,7 @@
     </div>
 
     <h2>Installation instructions</h2>
-    <p>It&rsquo;s as easy as &mdash;</p>
+    <p>It&rsquo;s as easy as:</p>
     <div class="six-col">
       <p class="command-line">
         <input class="command-line__input" value="$ sudo apt-add-repository ppa:juju/stable" readonly="readonly">

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -18,13 +18,13 @@
     <p class="intro">Try out OpenStack on a single machine or start building a production cloud on a cluster: you choose.</p>
     <div class="box box-highlight clearfix equal-height--vertical-divider">
       <div class="equal-height--vertical-divider__item six-col">
-        <h3>Single machine</h3>
+        <p class="intro">Single machine</p>
         <h2>Try OpenStack on a single&nbsp;machine</h2>
         <p>Conjure-up is an ideal tool for people who want to build an OpenStack cloud on a single machine using LXD containers.</p>
         <p><a href="/download/cloud/conjure-up">Try conjure-up on single machine&nbsp;&rsaquo;</a></p>
       </div>
       <div class="six-col last-col equal-height--vertical-divider__item">
-        <h3>Cluster</h3>
+        <p class="intro">Cluster</p>
         <h2>Build your own production&nbsp;cloud</h2>
         <p>Canonical&rsquo;s OpenStack Autopilot handles every aspect of your production cloud across multiple physical machines through installation, expansion and everyday operations.</p>
         <p><a href="/download/cloud/autopilot">Build a production cloud with Autopilot&nbsp;&rsaquo;</a></p>


### PR DESCRIPTION
## Done
- fixed the ebook row on /download/cloud/autopilot (previously removed class was actually needed)
- Removed an errant emdash which should have been a colon
- updated the markup of /download/cloud so the text above section headings aren't as big

## QA

Check pages in-browser.