### PR TITLE
update install instructions for conjure-up - snap version

### DIFF
--- a/templates/download/cloud/conjure-up.html
+++ b/templates/download/cloud/conjure-up.html
@@ -53,19 +53,7 @@
     <p>It&rsquo;s as easy as &mdash;</p>
     <div class="six-col">
       <p class="command-line">
-        <input class="command-line__input" value="$ sudo apt-add-repository ppa:juju/stable" readonly="readonly">
-        <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-      </p>
-      <p class="command-line">
-        <input class="command-line__input" value="$ sudo apt-add-repository ppa:conjure-up/next" readonly="readonly">
-        <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-      </p>
-      <p class="command-line">
-        <input class="command-line__input" value="$ sudo apt update" readonly="readonly">
-        <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-      </p>
-      <p class="command-line">
-        <input class="command-line__input" value="$ sudo apt install conjure-up" readonly="readonly">
+        <input class="command-line__input" value="$ snap install conjure-up --classic --beta" readonly="readonly">
         <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
       </p>
       <p class="command-line">


### PR DESCRIPTION
## Done

Updated the install instructions for conjure-up on the download page

## QA

 - go to `/download/cloud/conjure-up`
 - check that the install instructions now match the [copydoc](https://docs.google.com/document/d/1TXnoE_RZCgms1K3beJNjzYLNzZEIjfeuNYg_zhkYQTA/edit)