### PR TITLE
add support for a set number of articles in further reading blocks. R…

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -162,7 +162,8 @@ html.opera-mini {
     .header--kylin,
     .header--openstack,
     .header--server,
-    .header--upgrade  {
+    .header--upgrade,
+    .header--articles  {
         background-repeat: no-repeat;
         background-size: 2em 2em;
         background-position: top left;
@@ -194,6 +195,9 @@ html.opera-mini {
     }
     .header--upgrade {
         background-image: url("#{$asset-server-url}f68488b1-picto-upgrade-warmgrey.svg");
+    }
+    .header--articles {
+      background-image: url("#{$asset-server-url}8a199d55-picto-articles-warmgrey.svg");
     }
 
     .row-easy-ways {

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -33,7 +33,7 @@
   </div>
 </section>
 
-<section class="row row-white no-border">
+<section class="row row-white">
   <div class="strip-inner-wrapper equal-height">
     <div class="four-col align-center not-for-small equal-height__item equal-height__align-vertically">
       <img src="{{ ASSET_SERVER_URL }}1f1d581a-picto-quote-orange.svg" width="200" alt="" />
@@ -46,6 +46,8 @@
     </div>
   </div>
 </section>
+
+{% include "download/server/_other-ways.html" %}
 
 {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_cloud_bootstack" second_item="_download_cloud_buy_landscape" third_item="_download_documentation" %}
 

--- a/templates/download/server/_other-ways.html
+++ b/templates/download/server/_other-ways.html
@@ -7,12 +7,8 @@
             <div class="equal-height--vertical-divider">
                 <div class="equal-height--vertical-divider__item four-col">
                     {% if level_2 == 'cloud' %}
-                        <h3 class="header--upgrade">sudo apt install openstack</h3>
-                        <p>To setup Ubuntu OpenStack by hand run:</p>
-                        <pre><code>sudo apt install openstack</code></pre>
-                        <p>Followed by</p>
-                        <pre><code>conjure-up openstack</code></pre>
-                        <p><a class="external" href="http://conjure-up.io/">More information on conjure-up.io</a></p>
+                        <h3 class="header--articles">Further OpenStack reading</h3>
+                        {% include "templates/_further_reading_links.html" with feed="https://insights.ubuntu.com/tag/openstack/feed" limit=3 %}
                     {% else %}
                         {% include "download/shared/_buy_a_usb.html" %}
                     {% endif %}

--- a/templates/templates/_further_reading_links.html
+++ b/templates/templates/_further_reading_links.html
@@ -1,4 +1,8 @@
-{% get_rss_feed "https://insights.ubuntu.com/feed/" limit=4 as feed %}
+{% if limit %}
+    {% get_rss_feed "https://insights.ubuntu.com/feed/" limit=limit as feed %}
+{% else %}
+    {% get_rss_feed "https://insights.ubuntu.com/feed/" limit=5 as feed %}
+{% endif %}
 
 <ul class='contextual-footer__list'>
 {% for item in feed %}


### PR DESCRIPTION
## Done

 - Added the existing footer back on to the /download/cloud page
 - Modified the further reading template - number of items is configurable
 - Added a new header icon for articles using a standard picto

## QA

 - go to `/download/cloud` see that the bottom row - before the contextual footer - has a "Further OpenStack reading" section with 3 articles