### PR TITLE
Conjure-up intructions: removed terminal start-of-line dolalr signs a…

### DIFF
--- a/templates/download/cloud/conjure-up.html
+++ b/templates/download/cloud/conjure-up.html
@@ -53,11 +53,11 @@
     <p>It&rsquo;s as easy as:</p>
     <div class="six-col">
       <p class="command-line">
-        <input class="command-line__input" value="$ snap install conjure-up --classic --beta" readonly="readonly">
+        <input class="command-line__input" value="snap install conjure-up --classic --beta" readonly="readonly">
         <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
       </p>
       <p class="command-line">
-        <input class="command-line__input" value="$ conjure-up" readonly="readonly">
+        <input class="command-line__input" value="conjure-up" readonly="readonly">
         <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
       </p>
       <p>&hellip; and then follow the on-screen instructions.</p>


### PR DESCRIPTION
## Done

Removed dollar signs from some code that we expect users to copy and paste into terminals

## QA

Check that the instructions no longer have dollar signs