### PR TITLE
add min-heights to partner logo boxes on /server/hyperscale

### DIFF
--- a/static/css/section/_server.scss
+++ b/static/css/section/_server.scss
@@ -83,6 +83,17 @@
         }
       }
     }
+
+    .partner-list > li {
+
+      @media only screen and (min-width : $breakpoint-medium) {
+        min-height: 24rem;
+      }
+
+      @media only screen and (min-width: $breakpoint-large) {
+        min-height: 21rem;
+      }
+    }
   }
 
   // @subsection /server/contact-us


### PR DESCRIPTION
## Done

added min-height for med and large screen for partners boxes on /server/hyperscale

## QA

1. go to /server/hyperscale and look at the 'Hyperscale partners' section in S/M/L screens

## Issue / Card

Fixes #1325 

## Screenshots

small

*unchanged*

medium

![image](https://cloud.githubusercontent.com/assets/441217/22920802/c46988bc-f28e-11e6-9af5-104b253a22e7.png)


large

![image](https://cloud.githubusercontent.com/assets/441217/22920822/d6008eea-f28e-11e6-85fb-cfc1a681fb6a.png)
