### PR TITLE
update link on /cloud to /download/cloud/conjure-up

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -76,7 +76,7 @@
         <div class="eight-col">
             <h2>Try an OpenStack cloud with conjure-up</h2>
             <p>Conjure-up&rsquo;s ability to easily and quickly deploy real-world OpenStack on a single laptop using LXD containers is ideal for first-time users or developers.</p>
-            <p><a href="/download/cloud">Install OpenStack with conjure-up&nbsp;&rsaquo;</a></p>
+            <p><a href="/download/cloud/conjure-up">Install OpenStack with conjure-up&nbsp;&rsaquo;</a></p>
         </div>
         <div class="twelve-col">
             <div class="vimeo-container">


### PR DESCRIPTION
## Done

* updated link on the cloud overview to go to /download/cloud/conjure-up rather than /download/cloud

## QA

1. go to /cloud
2. see that the link in 'Try an OpenStack cloud with conjure-up' section now points to /download/cloud/conjure-up

## Issue / Card

Fixes #1318 
