### PR TITLE
change contextual footer on /cloud/openstack

### DIFF
--- a/templates/cloud/openstack/index.html
+++ b/templates/cloud/openstack/index.html
@@ -158,6 +158,6 @@
     </div>
 </section>
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_cloud_autopilot" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_cloud_buy_landscape" second_item="_cloud_contact_us" third_item="_cloud_further_reading" %}
 
 {% endblock content %}

--- a/templates/shared/contextual_footers/_download_cloud_buy_landscape.html
+++ b/templates/shared/contextual_footers/_download_cloud_buy_landscape.html
@@ -1,4 +1,4 @@
 <h3 class="contextual-footer__title">Need more licenses?</h3>
-<p class="contextual-footer__text">Have you built your Ubuntu OpenStack cloud and need more licenses?  You&rsquo;ll need to purchase Ubuntu Advantage licenses.</p>
+<p class="contextual-footer__text">Have you built your Ubuntu OpenStack cloud and need more licenses?  You&rsquo;ll need to purchase Ubuntu Advantage.</p>
 <p class="contextual-footer__text"><a href="https://buy.ubuntu.com/" class="button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Shop for Ubuntu Advantage', 'eventLabel' : 'Need more licenses?', 'eventValue' : undefined });">Buy now</a></p>
 <p class="contextual-footer__text">Or <a href="/support/contact-us" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Contact-us management', 'eventLabel' : 'Need more licenses?', 'eventValue' : undefined });">contact our sales team&nbsp;&rsaquo;</a></p>


### PR DESCRIPTION
## Done

* updated text of 'Need licenses' contextual footer and added it to /cloud/openstack


## QA

1. go to /cloud/openstack
2. see the left most contextual footer is now 'Need more licenses?'
3. see that the text has been made simpler, removing the word 'licenses' from the final sentence

## Issue / Card

Fixes #1319

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/22921844/290eb360-f293-11e6-824e-e328260bbf23.png)