### PR TITLE
fix typo on Ubuntu Advantage service description

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -377,7 +377,7 @@
                             <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>
                         </tr>
                         <tr>
-                            <td scope="row">24x7 phone and ticket support1 for all packages in Ubuntu main (see <a href="#response-times">Section 3</a>) and Canonical-maintained packages in backports and universe, except as defined in <a href="#kvm-guest-support">this section</a></td>
+                            <td scope="row">24x7 phone and ticket support for all packages in Ubuntu main (see <a href="#response-times">Section 3</a>) and Canonical-maintained packages in backports and universe, except as defined in <a href="#kvm-guest-support">this section</a></td>
                             <td></td>
                             <td></td>
                             <td><img width="16" height="16" alt="Yes" src="{{ ASSET_SERVER_URL }}c4b02d61-tick-orange.svg" /></td>


### PR DESCRIPTION
## Done

* remove extraneous '1' 

## QA

1. go to /legal/ubuntu-advantage/service-description
2. search for '24x7 phone and ticket support1' on live and see that it says '24x7 phone and ticket support' in the new branch

## Issue / Card

Fixes #1296 