### PR TITLE
removed dup headings on /core

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -107,11 +107,9 @@
 
         <div class="align-center twelve-col for-small equal-height--vertical-divider" style="padding-top: 2em;">
             <div class="align-center six-col equal-height--vertical-divider__item">
-                <h3 class="six-col">Classic Ubuntu 16.04</h3>
                 <img src="{{ ASSET_SERVER_URL }}629ed707-Ubuntu_Classic_vs_Core_-_Mobile_01.svg" width="260" alt="" />
             </div>
             <div class="align-center six-col  equal-height--vertical-divider__item last-col" >
-                <h3 class="six-col">Ubuntu Core 16</h3>
                 <img src="{{ ASSET_SERVER_URL }}a77f543b-Ubuntu_Classic_vs_Core_-_Mobile_02.svg" alt="" width="260"/>
             </div>
         </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -102,12 +102,6 @@
         </div>
 
         <div class="twelve-col not-for-small align-center" style="padding-top: 2em;">
-            <div class="six-col">
-                <h4 class="six-col">Classic Ubuntu 16.04</h4>
-            </div>
-            <div class="six-col last-col">
-                <h4 class="six-col">Ubuntu Core 16</h4>
-            </div>
             <img src="{{ ASSET_SERVER_URL }}8f0a3b34-Ubuntu_Classic_vs_Core_-_Desktop.svg" alt="" />
         </div>
 


### PR DESCRIPTION


## Done

removed headings as they are in the svg

``` html
            <div class="six-col">
                <h4 class="six-col">Classic Ubuntu 16.04</h4>
            </div>
            <div class="six-col last-col">
                <h4 class="six-col">Ubuntu Core 16</h4>
            </div>
```

I think it would ultimately be better to remove them from the graphic and leave the html ones in, but this was quicker


## QA

1. go to core
2. see the headings are in the svg in the 'Features' section

## Issue / Card

Fixes #1291 

## Screenshots

old

![image](https://cloud.githubusercontent.com/assets/441217/22966150/cb0ad6a6-f358-11e6-928e-d362ab9c8645.png)


updated

![image](https://cloud.githubusercontent.com/assets/441217/22966157/d2263d72-f358-11e6-944a-175165ae328f.png)
