### PR TITLE
changed link to point to landscape.canonical.com

### DIFF
--- a/templates/server/management.html
+++ b/templates/server/management.html
@@ -29,7 +29,7 @@
 				<p>Landscape is the systems management tool available with Ubuntu Advantage. It allows you to manage thousands of Ubuntu machines as easily as one, making the administration of Ubuntu desktops, servers and cloud instances more cost-effective.</p>
 			</div>
             <p><a href="https://buy.ubuntu.com/collections/ubuntu-advantage-for-servers" class="button--primary"><span class="external">Buy Ubuntu Advantage for servers</span></a></p>
-            <p><a href="/support">Find out more about Landscape&nbsp;&rsaquo;</a></p>
+            <p><a href="https://landscape.canonical.com" class="external">Find out more about Landscape</a></p>
 		</div>
     </div>
 </section>


### PR DESCRIPTION
## Done

* updated the link in the banner of /server/management to point to landscape.canonical.com over /support

## QA

1. go to /server/management
2. see that the link 'Find out more about Landscape' now goes to landscape.canonical.com and has an external link icon

## Issue / Card

Fixes #1289 