### PR TITLE
adding live patching to server table

### DIFF
--- a/templates/shared/_ubuntu_advantage_server.html
+++ b/templates/shared/_ubuntu_advantage_server.html
@@ -39,6 +39,12 @@
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
     </tr>
     <tr>
+      <th>Live Patching (16.04 only)</th>
+      <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
+      <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
+      <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>
+    </tr>
+    <tr>
       <th>10x5 phone and ticket support for all packages in Ubuntu main</th>
       <td>&nbsp;</td>
       <td><img src="{{ ASSET_SERVER_URL }}f1a7515d-tick-darkaubergine.svg" alt="Yes" /></td>


### PR DESCRIPTION
## Done

* added live patching to Ubuntu Advantage server shared include per [copy doc](https://docs.google.com/document/d/1Oqzs4utcIAdmFwZlSqlA6m5ioDlNnAjj_OTi_RHF2f8/edit#)

## QA

1. go to /server/management and see a new 'Live Patching (16.04 only)' row in the 'Ubuntu Advantage for servers' section

## Issue / Card

* request was in the copy doc

## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/22966567/a892d4b4-f35a-11e6-9510-1a0074bcd211.png)
