### PR TITLE
updating tracking links on /core page

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -23,8 +23,8 @@
             <div class="six-col">
                 <p>Ubuntu Core is a tiny, transactional version of Ubuntu for IoT devices and large container deployments. It runs a new breed of super-secure, remotely upgradeable Linux app packages known as snaps &dash; and it&rsquo;s trusted by leading IoT players, from chipset vendors to device makers and system integrators.</p>
             </div>
-            <p class="six-col"><a class="button--primary" href="http://developer.ubuntu.com/en/snappy/start/?utm_campaign=Device_FY17_CORE&amp;utm_medium=corepage&amp;utm_source=ubuntuwebsite&amp;utm_content="><span class="external">Download Ubuntu Core</span></a></p>
-            <p><a class="external" href="http://snapcraft.io/?utm_campaign=Device_FY17_CORE&amp;utm_medium=corepageintrosection&amp;utm_source=ubuntuwebsite&amp;utm_content=findoutmoreonsnap">Learn more about snaps</a></p>
+            <p class="six-col"><a class="button--primary" href="http://developer.ubuntu.com/en/snappy/start/?from=corepage"><span class="external">Download Ubuntu Core</span></a></p>
+            <p><a class="external" href="http://snapcraft.io/?from=corepage">Learn more about snaps</a></p>
         </div>
         <div class="six-col last-col not-for-small">
             <img class="row-hero__image" src="{{ ASSET_SERVER_URL }}53163a88-IOT_core_infographic.svg?w=600" alt="" />
@@ -40,19 +40,19 @@
               <img src="{{ ASSET_SERVER_URL }}2def20f4-iot_digital_signage_overview.jpg?w=300" class="twelve-col row--verticals__image" alt="" />
               <h3>Digital signage</h3>
               <p>With a small footprint and full OpenGL with reliable updates, Ubuntu Core provides a perfect platform for millions of digital signs.</p>
-              <p><a href="/internet-of-things/digital-signage?utm_campaign=Device_FY17_CORE&amp;utm_medium=verticalsection&amp;utm_source=corepage&amp;utm_content=findoutmoreondspage">Digital signage on Ubuntu&nbsp;&rsaquo;</a></p>
+              <p><a href="/internet-of-things/digital-signage">Digital signage on Ubuntu&nbsp;&rsaquo;</a></p>
           </div>
           <div class="four-col equal-height--vertical-divider__item">
               <img src="{{ ASSET_SERVER_URL }}1e37ff95-iot_overview_robotics.jpg?w=300" class="twelve-col row--verticals__image" alt="" />
               <h3>Robotics</h3>
               <p>With full support for ROS in Snapcraft, it&rsquo;s easy to enable apps on robots and drones, creating new ecosystems and business models.</p>
-              <p><a href="/internet-of-things/robotics?utm_campaign=Device_FY17_CORE&amp;utm_medium=verticalsection&amp;utm_source=corepage&amp;utm_content=findoutmoreonroboticspage">Robots and drones, rocking Ubuntu Core&nbsp;&rsaquo;</a></p>
+              <p><a href="/internet-of-things/robotics">Robots and drones, rocking Ubuntu Core&nbsp;&rsaquo;</a></p>
           </div>
           <div class="four-col equal-height--vertical-divider__item last-col">
               <img src="{{ ASSET_SERVER_URL }}3e480882-iot_gateways_product_image.jpg?w=300" class="twelve-col row--verticals__image" alt="" />
               <h3>Edge Gateways</h3>
               <p>Rich networking and protocol support make Ubuntu Core the perfect choice for your industrial gateways.</p>
-              <p><a href="/internet-of-things/gateways?utm_campaign=Device_FY17_CORE&amp;utm_medium=verticalsection&amp;utm_source=corepage&amp;utm_content=findoutmoreonedgegatewaypage">IoT gateways on Ubuntu&nbsp;&rsaquo;</a></p>
+              <p><a href="/internet-of-things/gateways">IoT gateways on Ubuntu&nbsp;&rsaquo;</a></p>
           </div>
         </div>
     </div>
@@ -181,7 +181,7 @@
         </div>
         <div class="nine-col last-col equal-height__item equal-height__align-vertically">
             <h2>Want to make your own Ubuntu Core device?</h2>
-            <p><a href="http://docs.ubuntu.com/core/en/guides/build-device/image-building">Build a custom Ubuntu Core image&nbsp;&rsaquo;</a></p>
+            <p><a href="http://docs.ubuntu.com/core/en/guides/build-device/image-building?from=corepage">Build a custom Ubuntu Core image&nbsp;&rsaquo;</a></p>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done

* updated tracking links on /core page and the [copy doc](https://docs.google.com/document/d/1QoM0Yqx4JfDJ2G3OPt5bds-ximG1jASmU_PWX4iff3E/edit#)

## QA

1. go to /core
2. see that internal links have no GET parameters
3. see that links to docs and dev have the '?from=corepage' GET parameter

## Issue / Card

Fixes #1322

