### PR TITLE
Fix secondary nav issues

### DIFF
--- a/templates/containers/_nav_secondary.html
+++ b/templates/containers/_nav_secondary.html
@@ -1,5 +1,5 @@
 <ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
-  <li><a{% if level_1 == 'cloud' and not level_2 %} class="active"{% endif %} href="/containers">Overview</a></li>
+  <li><a{% if level_1 == 'containers' and not level_2 %} class="active"{% endif %} href="/containers">Overview</a></li>
   <li><a{% if level_2 == 'lxd' %} class="active"{% endif %} href="/containers/lxd">LXD</a></li>
   <li><a{% if level_2 == 'kubernetes' %} class="active"{% endif %} href="/containers/kubernetes">Kubernetes</a></li>
   <li><a class="last-item{% if level_2 == 'docker-engine-ubuntu' %} active{% endif %}" href="/containers/docker-engine-ubuntu">Docker Engine on Ubuntu</a></li>

--- a/templates/containers/lxd.html
+++ b/templates/containers/lxd.html
@@ -7,7 +7,7 @@
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
-  {% include "templates/_nav_breadcrumb.html" with section_title="Cloud" page_title="lxd" %}
+  {% include "templates/_nav_breadcrumb.html" with section_title="Containers" page_title="lxd" %}
 </div>
 {% endblock second_level_nav_items %}
 


### PR DESCRIPTION
## Done

Fix level active indicator on containers homepage
Fix /containers/lxd section_title

## QA

Go to /containers and make sure ‘Overview’ in secondary nav is highlighted 
Go to Fix /containers/lxd and make sure the section title in secondary nav is Containers not Cloud


