### PR TITLE
Bump the latest LTS release to 16.04.2

### DIFF
--- a/templates/cloud/lxd.html
+++ b/templates/cloud/lxd.html
@@ -163,7 +163,7 @@
         <div class="eight-col last-col equal-height__item">
             <h2>Ultra-fast OpenStack with LXD</h2>
             <p>The combination of LXD and OpenStack makes for a very happy system administrator in a Linux‐oriented private cloud. All the agility of OpenStack, all the performance of your metal with no virt overhead.</p>
-            <p>As a validation point, we&rsquo;ve included the nova‐lxd driver in Ubuntu 16.04.1, and are committed to steering this into upstream OpenStack.</p>
+            <p>As a validation point, we&rsquo;ve included the nova‐lxd driver in Ubuntu 16.04.2, and are committed to steering this into upstream OpenStack.</p>
             <p>This new driver allows OpenStack instances to be scheduled as Linux containers. Images are booted from OpenStack&rsquo;s image service, Glance, and instances communicate over Neutron&rsquo;s networking functionality just like KVM based VMs do.</p>
         </div>
     </div>

--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -62,7 +62,7 @@
 				<tr><td>Ubuntu 17.04</td><td>Apr-2017</td><td>Jan-2018</td></tr>
 				<tr><td>Ubuntu 16.04.2 (v4.8)</td><td>Feb-2017</td><td>Aug-2017</td></tr>
 				<tr><td>Ubuntu 16.10</td><td>Oct-2016</td><td>Jul-2017</td></tr>
-				<tr><td>Ubuntu 16.04.1 (v4.4)</td><td>Aug-2016</td><td>Apr-2021</td></tr>
+				<tr><td>Ubuntu 16.04.2 (v4.4)</td><td>Aug-2016</td><td>Apr-2021</td></tr>
 				<tr><td>Ubuntu 14.04.5 (v4.4)</td><td>Aug-2016</td><td>May-2019</td></tr>
 				<tr><td>Ubuntu 16.04.0 (v4.4)</td><td>Apr-2016</td><td>Apr-2021</td></tr>
 				<tr><td>Ubuntu 14.04.4 (v4.2)</td><td>Feb-2016</td><td>Aug-2016</td></tr>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -3,7 +3,7 @@
 
 {# Release versions - update as appropriate #}
 {% with latest_release_name="YakketyYak" latest_release="16.10" latest_release_full='16.10' %}
-{% with lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.1" lts_release_full='16.04 LTS' lts_release_with_point="16.04.1" lts_release_full_with_point='16.04.1 <abbr title="long-term support">LTS</abbr>' %}
+{% with lts_release_name="XenialXerus" lts_release_no_point="16.04" lts_release="16.04.2" lts_release_full='16.04 LTS' lts_release_with_point="16.04.2" lts_release_full_with_point='16.04.2 <abbr title="long-term support">LTS</abbr>' %}
 {% with openstack_version="Mitaka" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done
s/16.04.1/16.04.2

## QA
- Check that all references to 16.04.1 have been updated to 16.04.2
- Check the download link goes to the right place. It will 404 for now.
