### PR TITLE
Update EOD image

### DIFF
--- a/templates/cloud/lxd.html
+++ b/templates/cloud/lxd.html
@@ -163,7 +163,7 @@
         <div class="eight-col last-col equal-height__item">
             <h2>Ultra-fast OpenStack with LXD</h2>
             <p>The combination of LXD and OpenStack makes for a very happy system administrator in a Linux‐oriented private cloud. All the agility of OpenStack, all the performance of your metal with no virt overhead.</p>
-            <p>As a validation point, we&rsquo;ve included the nova‐lxd driver in Ubuntu 16.04.2, and are committed to steering this into upstream OpenStack.</p>
+            <p>As a validation point, we&rsquo;ve included the nova‐lxd driver in Ubuntu 16.04, and are committed to steering this into upstream OpenStack.</p>
             <p>This new driver allows OpenStack instances to be scheduled as Linux containers. Images are booted from OpenStack&rsquo;s image service, Glance, and instances communicate over Neutron&rsquo;s networking functionality just like KVM based VMs do.</p>
         </div>
     </div>

--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -48,7 +48,7 @@
 		<p>The Ubuntu LTS enablement stacks provide newer kernel and X support for existing Ubuntu LTS releases. These can be installed manually, or are automatically shipped if installing from 12.04.2/14.04.2 and newer release media. These newer enablement stacks are meant for desktop and server, and even recommended for cloud or virtual images. The Ubuntu kernel support lifecycle is as follows:</p>
 	</div>
 	<div class="twelve-col">
-		<p><img src="{{ ASSET_SERVER_URL }}299d2531-kernel-release-eol-20161213.png" alt="" class="not-for-small" /></p>
+		<p><img src="{{ ASSET_SERVER_URL }}8705e8f8-kernel-release-eol-20170216.png" alt="" class="not-for-small" /></p>
 		<table class="for-small">
 			<thead>
 				<tr><th>Release</th><th>Released</th><th>End of life</th></tr>


### PR DESCRIPTION
## Done
Update EOD kernal image

## QA
- Check the kernal image at http://127.0.0.1:8001/info/release-end-of-life matches the spreadsheet [1]

[1] https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=1712489059

