### PR TITLE
add containers contact form. Add phone numbers to standard contact form template.

### DIFF
--- a/static/css/_scratch.scss
+++ b/static/css/_scratch.scss
@@ -127,3 +127,38 @@ header.banner .nav-primary li:hover ul:after {
 .u-full-width {
   width: 100%;
 }
+
+/// XXX phone number list boxes
+.phone-numbers {
+  border-radius: 4px;
+  box-shadow: 0px 0px 5px 0px rgba(0, 0, 0, .2);
+  overflow: hidden;
+  padding: 0;
+
+  &__title {
+    background-color: $light-grey;
+    padding: 15px $gutter-width;
+  }
+
+  &__list {
+    margin-left: 0;
+    padding: 0 $gutter-width;
+  }
+
+  &__list-item {
+    border-bottom: 1px dotted $warm-grey;
+    list-style: none;
+    margin-bottom: 0;
+    padding: 10px 0;
+
+    &:last-of-type {
+      border: 0;
+      margin-bottom: 0;
+      padding-bottom: 0;
+    }
+  }
+
+  &__number {
+    float: right;
+  }
+}

--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -1,0 +1,31 @@
+{% extends "containers/base_containers.html" %}
+{% block title %}Contact us | Containers {% endblock %}
+
+{% block second_level_nav_items %}
+<div class="strip-inner-wrapper">
+  {% include "templates/_nav_breadcrumb.html" with section_title="Containers" page_title="Contact us" %}
+</div>
+{% endblock second_level_nav_items %}
+
+{% block content %}
+<section class="row row-hero no-border no-margin-bottom no-padding-bottom strip-light">
+  <div class="strip-inner-wrapper">
+    {% include "shared/_cloud-contact-us-form.html" with  h1="Contact us about containers" intro_text="Fill in your details below and a member of our sales team will be in touch." formid='1964'  lpId='3828' returnURL='https://www.ubuntu.com/containers/thank-you' %}
+  </div>
+</section>
+
+{% endblock content %}
+
+{% block footer_extra %}
+<script src="{{ ASSET_SERVER_URL }}5d7e5bbf-jquery-2.2.0.min.js"></script>
+<script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
+<script>
+  $("#mktoForm").validate({
+    errorElement: "span",
+    errorClass: "mktFormMsg mktError",
+    onkeyup: false,
+    onclick: false,
+    onblur: false
+  });
+</script>
+{% endblock footer_extra %}

--- a/templates/containers/thank-you.html
+++ b/templates/containers/thank-you.html
@@ -1,0 +1,35 @@
+{% extends "containers/base_containers.html" %}
+
+{% block title %}Thank you | Containers{% endblock %}
+
+{% block second_level_nav_items %}
+<div class="strip-inner-wrapper">
+  {% include "templates/_nav_breadcrumb.html" with section_title="Containers" subsection_title="Contact us" page_title="Thank you"  %}
+</div>
+{% endblock second_level_nav_items %}
+
+{% block content %}
+  {% include "shared/_thank_you.html" with thanks_context="enquiring about containers" %}
+{% endblock content %}
+
+{% block footer_extra %}
+<!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
+<script>
+/* <![CDATA[ */
+var google_conversion_id = 1012391776;
+var google_conversion_language = "en";
+var google_conversion_format = "3";
+var google_conversion_color = "ffffff";
+var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
+var google_conversion_value = 0;
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js">
+</script>
+<noscript>
+<div style="display:inline;">
+<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+</div>
+</noscript>
+{{ marketo }}
+{% endblock footer_extra %}

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -1,87 +1,102 @@
-        <div class="eight-col">
-            <h1>{{h1}}</h1>
-            <p>{{intro_text}}</p>
-        </div>
-        <div class="eight-col">
-            <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm">
-                <fieldset>
-                    <h3>About you</h3>
-                    <ul class="no-bullets">
-                        <li class="mktFormReq mktField">
-                            <label for="FirstName" class="mktoLabel">First name:</label>
-                            <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
-                        </li>
-                        <li class="mktFormReq mktField">
-                            <label for="LastName" class="mktoLabel">Last name:</label>
-                            <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
-                        </li>
-                        <li class="mktFormReq mktField">
-                            <label for="Email" class="mktoLabel">Email address:</label>
-                            <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
-                        </li>
-                        <li class="mktFormReq mktField">
-                            <label for="Phone" class="mktoLabel">Phone number:</label>
-                            <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
-                        </li>
-                        <!-- country -->
-                        {% include "shared/forms/_country.html" %}
-                        <!-- state/province -->
-                        {% include "shared/forms/_state.html" %}
-                    </fieldset>
+<div class="eight-col">
+  <h1>{{h1}}</h1>
+  <p>{{intro_text}}</p>
+</div>
+<div class="eight-col">
+  <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm">
+    <fieldset>
+      <h3>About you</h3>
+      <ul class="no-bullets">
+        <li class="mktFormReq mktField">
+          <label for="FirstName" class="mktoLabel">First name:</label>
+          <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+        </li>
+        <li class="mktFormReq mktField">
+          <label for="LastName" class="mktoLabel">Last name:</label>
+          <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+        </li>
+        <li class="mktFormReq mktField">
+          <label for="Email" class="mktoLabel">Email address:</label>
+          <input required id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField mktoRequired" />
+        </li>
+        <li class="mktFormReq mktField">
+          <label for="Phone" class="mktoLabel">Phone number:</label>
+          <input required id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+        </li>
+        <!-- country -->
+        {% include "shared/forms/_country.html" %}
+        <!-- state/province -->
+        {% include "shared/forms/_state.html" %}
+      </fieldset>
 
-                    <fieldset>
-                        <h3>About your company</h3>
-                        <ul class="no-bullets">
-                            <li class="mktFormReq mktField">
-                                <label for="Company" class="mktoLabel">Company name:</label>
-                                <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
-                            </li>
-                            <li class="mktFormReq mktField">
-                                <label for="Title" class="mktoLabel">Job title:</label>
-                                <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
-                            </li>
-                        </ul>
-                    </fieldset>
+      <fieldset>
+        <h3>About your company</h3>
+        <ul class="no-bullets">
+          <li class="mktFormReq mktField">
+            <label for="Company" class="mktoLabel">Company name:</label>
+            <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
+          </li>
+          <li class="mktFormReq mktField">
+            <label for="Title" class="mktoLabel">Job title:</label>
+            <input required id="Title" name="Title" maxlength="255" type="text" class="mktoField mktoRequired" />
+          </li>
+        </ul>
+      </fieldset>
 
-                    <fieldset>
-                        <h3>Your comments</h3>
-                        <ul class="no-bullets">
-                            <li class="mktFormReq mktField">
-                                <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                                <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" class="mktoField mktoRequired" maxlength="2000"></textarea>
-                            </li>
-                        </ul>
-                    </fieldset>
+      <fieldset>
+        <h3>Your comments</h3>
+        <ul class="no-bullets">
+          <li class="mktFormReq mktField">
+            <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
+            <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" class="mktoField mktoRequired" maxlength="2000"></textarea>
+          </li>
+        </ul>
+      </fieldset>
 
-                    <fieldset>
-                        <ul class="no-bullets">
-                            <li class="mktField">
-                                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
-                            </li>
-                            <li class="mktField">
-                                <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox" />
-                                <label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would also like to receive the monthly Cloud Newsletter.</label>
-                            </li>
-                            <li>
-                                All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>.
-                            </li>
-                            <li class="mktField">
-                                <button type="submit" class="mktoButton"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
-                            </li>
-                        </ul>
+      <fieldset>
+        <ul class="no-bullets">
+          <li class="mktField">
+            <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+            <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
+          </li>
+          <li class="mktField">
+            <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox" />
+            <label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would also like to receive the monthly Cloud Newsletter.</label>
+          </li>
+          <li>
+            All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank">privacy policy</a>.
+          </li>
+          <li class="mktField">
+            <button type="submit" class="mktoButton"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+          </li>
+        </ul>
 
-                        <!-- hidden fields -->
-                        <input type="hidden" name="formid" class="mktoField" value="{{formid}}" />
-                        <input type="hidden" name="lpId" class="mktoField" value="{{lpId}}" />
-                        <input type="hidden" name="subId" class="mktoField" value="30" />
-                        <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335" />
-                        <input type="hidden" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/Cloud-contact-us.html?cr={creative}&amp;kw={keyword}" />
-                        <input type="hidden" name="cr" class="mktoField" value="" />
-                        <input type="hidden" name="kw" class="mktoField" value="" />
-                        <input type="hidden" name="q" class="mktoField" value="" />
-                        <input type="hidden" name="returnURL" value="{{returnURL}}" />
-                        <input type="hidden" name="retURL" value="{{returnURL}}" />
-                    </fieldset>
-                </form>
-            </div>
+        <!-- hidden fields -->
+        <input type="hidden" name="formid" class="mktoField" value="{{formid}}" />
+        <input type="hidden" name="lpId" class="mktoField" value="{{lpId}}" />
+        <input type="hidden" name="subId" class="mktoField" value="30" />
+        <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335" />
+        <input type="hidden" name="lpurl" class="mktoField" value="https://pages.ubuntu.com/Cloud-contact-us.html?cr={creative}&amp;kw={keyword}" />
+        <input type="hidden" name="cr" class="mktoField" value="" />
+        <input type="hidden" name="kw" class="mktoField" value="" />
+        <input type="hidden" name="q" class="mktoField" value="" />
+        <input type="hidden" name="returnURL" value="{{returnURL}}" />
+        <input type="hidden" name="retURL" value="{{returnURL}}" />
+      </fieldset>
+    </form>
+</div>
+
+<div class="four-col last-col phone-numbers">
+  <h3 class="phone-numbers__title">Any questions? Call us</h3>
+  <ul class="phone-numbers__list">
+    <li class="phone-numbers__list-item">Americas	<a href="tel:+1 7372040291" class="phone-numbers__number">+1 7372040291</a></li>
+    <li class="phone-numbers__list-item">France	<a href="tel:+33 184889319" class="phone-numbers__number">+33 184889319</a></li>
+    <li class="phone-numbers__list-item">Germany	<a href="tel:+49 61512746816" class="phone-numbers__number">+49 61512746816</a></li>
+    <li class="phone-numbers__list-item">Japan	<a href="tel:+81 345777736" class="phone-numbers__number">+81 345777736</a></li>
+    <li class="phone-numbers__list-item">Korea	<a href="tel:+82 318108759" class="phone-numbers__number">+82 318108759</a></li>
+    <li class="phone-numbers__list-item">Mexico	<a href="tel:+52 5541636681" class="phone-numbers__number">+52 5541636681</a></li>
+    <li class="phone-numbers__list-item">Spain	<a href="tel:+34 932201131" class="phone-numbers__number">+34 932201131</a></li>
+    <li class="phone-numbers__list-item">Taiwan	<a href="tel:+88 6255924779" class="phone-numbers__number">+88 6255924779</a></li>
+    <li class="phone-numbers__list-item">UK and RoW	<a href="tel:+44 2036565291" class="phone-numbers__number">+44 2036565291</a></li>
+  </ul>
+</div>

--- a/templates/shared/_thank_you.html
+++ b/templates/shared/_thank_you.html
@@ -1,5 +1,5 @@
 <section class="row row-hero no-border strip-light">
-  {% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop"  or level_1 == "support" %}<div class="strip-inner-wrapper">{% endif %}
+  {% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "containers" %}<div class="strip-inner-wrapper">{% endif %}
     <div class="equal-height">
     	<div class="thank-you eight-col equal-height__item">
     		<h1>Thank you for {{ thanks_context }}</h1>
@@ -9,6 +9,6 @@
     		<img src="{{ ASSET_SERVER_URL }}52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />
     	</div>
     </div>
-  {% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" %}</div>{% endif %}
+  {% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "containers" %}</div>{% endif %}
 </section>
 {% include "shared/_thank_you_footer.html" %}

--- a/templates/shared/_thank_you_footer.html
+++ b/templates/shared/_thank_you_footer.html
@@ -1,5 +1,5 @@
 <div class="row equal-height no-border strip-light">
-  {% if level_1 == "mobile" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" or level_1 == "core" %}<div class="strip-inner-wrapper">{% endif %}
+  {% if level_1 == "mobile" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" or level_1 == "core" or level_1 == "containers" %}<div class="strip-inner-wrapper">{% endif %}
 	<h2 class="twelve-col">More about our enterprise services</h2>
 	<ul id="thank-you-extra" class="no-bullets">
 		<li class="advantage four-col first">
@@ -18,5 +18,5 @@
 			<p><a href="/support">Learn about Landscape&nbsp;&rsaquo;</a></p>
 		</li>
 	</ul>
-	{% if level_1 == "mobile" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" or level_1 == "core" %}</div>{% endif %}
+	{% if level_1 == "mobile" or level_1 == "download" or level_1 == "server" or level_1 == "cloud" or level_1 == "desktop" or level_1 == "support" or level_1 == "internet-of-things" or level_1 == "core" or level_1 == "containers" %}</div>{% endif %}
 </div><!-- end row-->


### PR DESCRIPTION
## Done

New form added on /containers/contact-us along with a thank-you page

## QA

Check in browser:
 - `/containers/contact-us`
 - `/containers/thank-you`

[copy](https://docs.google.com/document/d/1eTF2u8oOFGg-h-sQQwZtx3D6pOfqlJSXCuNo5-dh3Fg/edit#)
[design](https://www.dropbox.com/work/00_web_team/_ubuntu.com/containers/Contact%20us/Deliverables?preview=Contact-us-card.jpg) (the tel: has made them styled like links)