### PR TITLE
fix for stepped lists until it's fixed upstream

### DIFF
--- a/static/css/_scratch.scss
+++ b/static/css/_scratch.scss
@@ -162,3 +162,13 @@ header.banner .nav-primary li:hover ul:after {
     float: right;
   }
 }
+
+/// XXX Fix for stepped-list being broken at *exactly* 768px
+
+.list-stepped__item:before {
+    @media only screen and (width: 768px) {
+      margin-left: 0 !important;
+      margin-bottom: 20px !important;
+      float: none !important;
+    }
+}


### PR DESCRIPTION
## Done

Fixed stepped lists at exactly 768px. We need a better solution in Vanilla but this is a quick fix for now.

## QA

Go to any stepped-list page (e.g., `/download/cloud/conjure-up`) and check it at all viewports but specifically exactly 768px wide.