### PR TITLE
Remove the 'featured' restriction on the partners logo feed

### DIFF
--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -114,7 +114,7 @@
     <div class="twelve-col">
         <h2 class="muted-heading">Partnering with industry leaders</h2>
         <ul class="inline-logos no-margin dynamic-logos">
-          {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Containers&featured=true" limit=10 as container_partners %}
+          {% get_json_feed "http://partners.ubuntu.com/partners.json?technology__name=Containers" limit=10 as container_partners %}
           {% for partner in container_partners %}
             <li class="inline-logos__item">
               <img class="inline-logos__image" src="{{ partner.logo }}" alt="{{ partner.name }}" title="{{ partner.name }}" />


### PR DESCRIPTION
## Done

Updated the feed to include everything in the "containers" technology list

## QA

See that all the partners are now showing up on `/containers`