### PR TITLE
remove —beta from /download/cloud/conjure-up page

### DIFF
--- a/templates/download/cloud/conjure-up.html
+++ b/templates/download/cloud/conjure-up.html
@@ -63,7 +63,7 @@
             <p>Getting OpenStack running on your computer is easy with conjure-up.</p>
             <p>From the command line type the commands below and follow the step-by-step instructions:</p>
             <p class="command-line">
-              <input class="command-line__input" value="snap install conjure-up --classic --beta" readonly="readonly">
+              <input class="command-line__input" value="snap install conjure-up --classic" readonly="readonly">
               <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
             </p>
             <p class="command-line">


### PR DESCRIPTION
## Done

* remove '-- beta' from /download/cloud/conjure-up
* updated the [copy doc](https://docs.google.com/document/d/1TXnoE_RZCgms1K3beJNjzYLNzZEIjfeuNYg_zhkYQTA/edit) updated

## QA

1. go to /download/cloud/conjure-up
2. see that --beta is removed from the `$ snap install conjure-up --classic` command

## Issue / Card

Fixes #1376