### PR TITLE
turns out that 'whitepaper' isn't a word; corrected two instances

### DIFF
--- a/templates/containers/shared/_whitepaper.html
+++ b/templates/containers/shared/_whitepaper.html
@@ -6,7 +6,7 @@
     <div class="eight-col equal-height__item equal-height__align-vertically last-col">
       <h2>The no-nonsense way to accelerate your business with containers</h2>
       <p>This white paper explains why containers are so popular and how to leverage them in your organisation. Learn the benefits of process containers and machine containers. Deep-dive into the two main software tools, Docker and LXD, that are used to manipulate containers.</p>
-      <p><a href="https://pages.ubuntu.com/container-whitepaper.html" class="button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Container whitepaper: {{ level_1 }} {{ level_2 }}', 'eventLabel' : 'Download the whitepaper', 'eventValue' : undefined });"><span class="external">Download the whitepaper</span></a></p>
+      <p><a href="https://pages.ubuntu.com/container-whitepaper.html" class="button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Container whitepaper: {{ level_1 }} {{ level_2 }}', 'eventLabel' : 'Download the white paper', 'eventValue' : undefined });"><span class="external">Download the white paper</span></a></p>
     </div>
   </div>
 </section>

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -36,17 +36,17 @@
             <li class="four-col equal-height--vertical-divider__item">
                 <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}eab2ecff-azeti_logo.png?h=75" alt="" />
                 <p>Azeti uses Ubuntu Core to improve deployment operations and security for a wide range of industries.</p>
-                <p><a class="external" href="https://pages.ubuntu.com/AzetiCS.html?utm_campaign=Device_FY17_IOT&utm_medium=edgegatewaycontentblock&utm_source=ubuntuwebsite&utm_content=azeticasestudy">Read the case study</a></p>
+                <p><a class="external" href="https://pages.ubuntu.com/AzetiCS.html?utm_campaign=Device_FY17_IOT&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=azeticasestudy">Read the case study</a></p>
             </li>
             <li class="four-col equal-height--vertical-divider__item">
                 <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}25517997-cloud_plugs_logo.png?h=75" alt="" />
                 <p>Watch CloudPlugs define Industry 4.0, the convergence of information and operations.</p>
-                <p><a class="external" href="https://www.brighttalk.com/webcast/6793/218271?utm_campaign=fy17-vertical-edgegateway-webinar&utm_medium=edgegatewaycontentblock&utm_source=ubuntuwebsite&utm_content=cloudplugs">Watch the webinar</a></p>
+                <p><a class="external" href="https://www.brighttalk.com/webcast/6793/218271?utm_campaign=fy17-vertical-edgegateway-webinar&amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=cloudplugs">Watch the webinar</a></p>
             </li>
             <li class="four-col last-col equal-height--vertical-divider__item no-margin-bottom">
                 <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}3c803253-Eclipse-logo-2014.svg?h=75" alt="" />
                 <p>The Eclipse IoT Working Group outlines the three software stacks required for IoT.</p>
-                <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf?utm_campaign=Device_FY17_IOT_Vertical_EG&utm_medium=edgegatewaycontentblock&utm_source=ubuntuwebsite&utm_content=eclipsewhitepaper">Read the white paper</a></p>
+                <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf?utm_campaign=Device_FY17_IOT_Vertical_EG&amp;amp;utm_medium=edgegatewaycontentblock&amp;utm_source=ubuntuwebsite&amp;utm_content=eclipsewhitepaper">Read the white paper</a></p>
             </li>
         </ul>
     </div>

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -46,7 +46,7 @@
             <li class="four-col last-col equal-height--vertical-divider__item no-margin-bottom">
                 <img class="gateways-logo" src="{{ ASSET_SERVER_URL }}3c803253-Eclipse-logo-2014.svg?h=75" alt="" />
                 <p>The Eclipse IoT Working Group outlines the three software stacks required for IoT.</p>
-                <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf?utm_campaign=Device_FY17_IOT_Vertical_EG&utm_medium=edgegatewaycontentblock&utm_source=ubuntuwebsite&utm_content=eclipsewhitepaper">Read the whitepaper</a></p>
+                <p><a class="external" href="http://insights.ubuntu.com/wp-content/uploads/4a5b/Eclipse-IoT-White-Paper-The-Three-Software-Stacks-Required-for-IoT-Architectures.pdf?utm_campaign=Device_FY17_IOT_Vertical_EG&utm_medium=edgegatewaycontentblock&utm_source=ubuntuwebsite&utm_content=eclipsewhitepaper">Read the white paper</a></p>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
## Done

Corrected two misspellings of "white paper" as "whitepaper"
