### PR TITLE
.inline-logos changes small screen margin

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -829,3 +829,12 @@ table {
     width: 100%;
   }
 }
+
+/// XXX inline-logo override for small screens
+.inline-logos {
+  margin: 20px 20px 20px 0;
+
+  @media only screen and (min-width: $breakpoint-medium) {
+    margin: 0 0 20px 0;
+  }
+}


### PR DESCRIPTION
## Done

* made margins for inline-logos look better on small screens

## QA

1. go to /containers/kubernetes and look at the logo cloud on S/M/L screens

## Issue / Card

Fixes #1375 

## Screenshots

before

![image](https://cloud.githubusercontent.com/assets/441217/23339044/80e58c4e-fc11-11e6-987e-00e10aca35b0.png)

after

![image](https://cloud.githubusercontent.com/assets/441217/23339035/62886348-fc11-11e6-9503-2edcef57b235.png)
