### PR TITLE
fixed angle brackets on provisioning download page

### DIFF
--- a/templates/download/server/provisioning.html
+++ b/templates/download/server/provisioning.html
@@ -262,7 +262,7 @@
                         <input class="command-line__input" value="sudo maas createadmin" readonly="readonly">
                         <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
                     </p>
-                    <p>Login to the MAAS UI at http://<your.maas.ip>:5240/MAAS/</p>
+                    <p>Login to the MAAS UI at http://&lt;your.maas.ip&gt;:5240/MAAS/</p>
                 </div>
             </li>
 


### PR DESCRIPTION
## Done

1. added html entities for local host

## QA

1. go to /download/server/provisioning
2. see that Login to the MAAS UI at http://&lt;your.maas.ip&gt;:5240/MAAS/ is visible