### PR TITLE
add maas webinar takeunder

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -119,7 +119,7 @@
 <section class="row row-featured strip no-border">
     <div class="strip-inner-wrapper equal-height">
         {% include "takeovers/takeunders/_iot-02-2017.html" %}
-        {% include "takeovers/takeunders/_mwc-2017.html" %}
+        {% include "takeovers/takeunders/_maas-webinar.html" %}
     </div>
 </section>
 

--- a/templates/takeovers/takeunders/_iot-02-2017.html
+++ b/templates/takeovers/takeunders/_iot-02-2017.html
@@ -3,7 +3,7 @@
         <img class="featured__image featured--right__image not-for-small" src="{{ ASSET_SERVER_URL }}3aa7e9a6-picto-articles-white.svg" width="150" alt="" />
     </div>
     <div class="six-col prepend-one append-one no-margin-bottom">
-        <h2 class="featured--right__title"><a class="featured__content" href="https://pages.ubuntu.com/IoT-Security-whitepaper.html?utm_source=Takeunder&amp;utm_campaign=3)%20Device_FY17_IOT_IoTSecurityWhitepaper&amp;utm_medium=Banner" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'IoT security white paper takeunder', 'The latest on IoT security']);">The latest on IoT security&nbsp;&rsaquo;</a></h2>
+        <h2 class="featured--right__title"><a class="featured__content" href="https://pages.ubuntu.com/IoT-Security-whitepaper.html?utm_source=Takeunder&amp;utm_campaign=3)%20Device_FY17_IOT_IoTSecurityWhitepaper&amp;utm_medium=Banner" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'IoT security white paper takeunder', 'The latest on IoT security']);">The latest information on IoT security&nbsp;&rsaquo;</a></h2>
         <p class="featured__content">Get rid of security vulnerabilities with help from our newest white&nbsp;paper.</p>
     </div>
 </div>

--- a/templates/takeovers/takeunders/_maas-webinar.html
+++ b/templates/takeovers/takeunders/_maas-webinar.html
@@ -1,0 +1,9 @@
+<div class="featured--right equal-height__item">
+  <div class="six-col prepend-one append-one no-margin-bottom">
+    <h2 class="featured--right__title"><a class="featured__content" href="http://ubunt.eu/cE0iPD" onclick="_gaq.push(['_trackEvent', 'Homepage Link', 'MAAS webinar takeunder', 'Cloud-ready servers in minutes']);">Cloud-ready servers in minutes&nbsp;&rsaquo;</a></h2>
+    <p class="featured__content">Join our webinar and learn how to leverage your hardware infrastructure more efficiently.</p>
+  </div>
+  <div class="four-col last-col align-center not-for-small">
+    <img class="featured__image featured--right__image not-for-small" src="{{ ASSET_SERVER_URL }}7e7692dd-webinar-takeunder.svg" width="200" alt="" />
+  </div>
+</div>


### PR DESCRIPTION
## Done
Added a new takeunder on the homepage for a maas webinar.
Modified the existing IoT takeunder so the content sits well with the new one.

## QA

View the homepage at all viewports.