### PR TITLE
add javascript linting

### DIFF
--- a/gulp/lint.js
+++ b/gulp/lint.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var sassLint = require('gulp-sass-lint');
 var exec = require('child_process').exec;
+var jshint = require('gulp-jshint');
 
 gulp.task('lint:sass', function() {
   return gulp.src('static/css/**/*.s+(a|c)ss')
@@ -14,4 +15,10 @@ gulp.task('lint:spellcheck', function(cb) {
     console.log(stdout);
     cb(err);
   });
+});
+
+gulp.task('lint:javascript', function () {
+  gulp.src(['static/js/*.js', '!./static/js/polyfills.js'])
+    .pipe(jshint())
+    .pipe(jshint.reporter());
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,12 +17,16 @@ wrench.readdirSyncRecursive('./gulp').filter(function(file) {
 /* Gulp help instructions triggered as Gulp default task */
 gulp.task('help', function() {
   console.log('develop - Watch sass files and generate unminified CSS for development');
-  console.log('test  - Lint Sass');
+  console.log('test - Lint Sass and JavaScript');
+  console.log('lint-sass - Lint Sass');
+  console.log('lint-javascript - Lint JavaScript');
   console.log('build  - Lint Sass files and generate minified CSS for production');
 });
 
 /* Gulp default task list */
 gulp.task('default', ['help']);
 gulp.task('develop', ['watch', 'sass:develop']);
-gulp.task('test', ['lint:sass', 'lint:spellcheck']);
+gulp.task('test', ['lint:sass', 'lint:javascript']);
+gulp.task('lint-js', ['lint:javascript']);
+gulp.task('lint-sass', ['lint:sass']);
 gulp.task('build', ['lint:sass', 'sass:build']);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "3.1.1",
     "gulp-cssnano": "^2.1.2",
+    "jshint": "2.9.4",
+    "gulp-jshint": "^2.0.4",
     "gulp-rename": "1.2.2",
     "gulp-sass": "3.1.0",
     "gulp-sass-lint": "1.3.2",


### PR DESCRIPTION
## Done

Added JavaScript linting provided by jsHint to the gulp tests.

## QA

See that the travis tests now include JS

Try:
```bash
npm i
gulp test
gulp test-js
gulp test-sass
```
And see the various linting outputs